### PR TITLE
force deploy sanity graphql

### DIFF
--- a/.github/workflows/deploySanity.yml
+++ b/.github/workflows/deploySanity.yml
@@ -41,4 +41,4 @@ jobs:
 
       - name: Deploy Sanity GraphQL
         run: |
-          SANITY_AUTH_TOKEN="${{ secrets.SANITY_DEPLOY_TOKEN }}" pnpm run deploy-sanity-graphql
+          SANITY_AUTH_TOKEN="${{ secrets.SANITY_DEPLOY_TOKEN }}" pnpm run deploy-sanity-graphql --force


### PR DESCRIPTION
In CI, we don't want the sanity graphql push to fail since we are assuming:

1. the code just merged has been reviewed and is good to go
2. we don't want to end up in a weird state where what we thought we were deploying didn't actually deploy

Users can still push to sanity graphql locally, but should keep in mind it will be wiped out whenever a PR is merged.
