### PR TITLE
add caching to category pages

### DIFF
--- a/packages/nextjs/utils/getCategoryServerSideProps.ts
+++ b/packages/nextjs/utils/getCategoryServerSideProps.ts
@@ -2,12 +2,16 @@ import { GetServerSideProps } from "next";
 import { GetCategoriesDocument } from "utils/generated/graphql";
 import { initializeUrql } from "utils/urql";
 
-export const getCategoryServerSideProps: GetServerSideProps = async () => {
+export const getCategoryServerSideProps: GetServerSideProps = async ({ req, res }) => {
   const { client, ssrCache } = initializeUrql();
 
   // This query is used to populate the cache for the query
   // used on this page.
   await client?.query(GetCategoriesDocument).toPromise();
+
+  // set caching response header
+  // note: when running `next dev`, these headers are overwritten to prevent local caching
+  res.setHeader("Cache-Control", "public, s-maxage=60, stale-while-revalidate=120");
 
   return {
     props: {


### PR DESCRIPTION
# What's in the PR?

In order to cache SSR pages, the Cache-Control response header needs to be added. For now, I'm only adding it to the categories page. Later on, we can adjust caching as necessary.

Although we haven't set up purging yet, the cache lifetime is low (60s), so I don't anticipate any major problems.

## Testing notes

Tested that caching is working by using the following command:
`# curl --head <vercel preview url>`

```sh
curl --head https://nextjs-sanity-fe-git-add-response-header-formidable-labs.vercel.app/
```

Here's the relevant response headers we want to see:
```sh
x-vercel-cache: HIT
age: 31
server: Vercel
```

x-vercel-cache: HIT means it was cached correctly and AGE is how long the content has been cached. 

Note that when we add Fastly in front of Vercel, we will no longer be looking for the Vercel cache hit header, but the Fastly one instead.