### PR TITLE
add workflow to purge after production deployments

### DIFF
--- a/.github/workflows/purgeFastly.yml
+++ b/.github/workflows/purgeFastly.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   purge:
-    if: ${{ github.event.deployment.environment == "production" || inputs.manual == true}}
+    if: ${{ github.event.deployment.environment == 'production' || inputs.manual == true }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@v3


### PR DESCRIPTION
This was the least intrusive method I found to make purging after deployments work.

It relies on the Vercel GH integration to create a "deployment" event after a deployment.

The workflow I created is triggered when a deployment event occurs, and if it's a 'production' environment event that means we should purge.