### PR TITLE
Simple header active link indicator

### DIFF
--- a/packages/nextjs/components/Header/DesktopNavItem.tsx
+++ b/packages/nextjs/components/Header/DesktopNavItem.tsx
@@ -1,14 +1,23 @@
 import Link from "next/link";
+import { useRouter } from "next/router";
+import { motion } from "framer-motion";
 
 type DesktopNavItemProps = {
   label: string;
   href: string;
 };
 
-export const DesktopNavItem = ({ label, href }: DesktopNavItemProps) => (
-  <li key={label} className="text-blue text-body-reg mr-4 last:mr-0">
-    <Link href={href}>
-      <a>{label}</a>
-    </Link>
-  </li>
-);
+export const DesktopNavItem = ({ label, href }: DesktopNavItemProps) => {
+  const router = useRouter();
+
+  return (
+    <li key={label} className={"text-blue text-body-reg mr-1 last:mr-0 py-1 px-4 rounded-2xl relative"}>
+      <Link href={href} passHref>
+        <a>{label}</a>
+      </Link>
+      {router.pathname === href && (
+        <motion.div layoutId="activeIndicator" className="absolute inset-0 rounded-2xl border-2"></motion.div>
+      )}
+    </li>
+  );
+};

--- a/packages/nextjs/components/Header/MobileHeaderItems.tsx
+++ b/packages/nextjs/components/Header/MobileHeaderItems.tsx
@@ -1,12 +1,15 @@
 import { NAV_ITEMS } from "./NavItems";
 import classNames from "classnames";
 import Link from "next/link";
+import { useRouter } from "next/router";
 type MobileHeaderItemsProps = {
   navOpen: boolean;
   onMobileNavClose: () => void;
 };
 
 export const MobileHeaderItems = ({ navOpen, onMobileNavClose }: MobileHeaderItemsProps) => {
+  const router = useRouter();
+
   return (
     <ul
       className={classNames("flex", "flex-col", "sm:hidden", "bg-yellow", "text-blue", "transition-all", {
@@ -17,11 +20,14 @@ export const MobileHeaderItems = ({ navOpen, onMobileNavClose }: MobileHeaderIte
       {navOpen &&
         NAV_ITEMS?.map(({ label, href }) => {
           return (
-            <li key={href} className={`border-b border-b-blue text-h4 py-4 px-3`}>
+            <li
+              key={href}
+              className={classNames("border-b border-b-blue text-h5 py-4 px-3", {
+                "font-bold": router.pathname === href,
+              })}
+            >
               <Link href={href}>
-                <a className="text-xl" onClick={onMobileNavClose}>
-                  {label}
-                </a>
+                <a onClick={onMobileNavClose}>{label}</a>
               </Link>
             </li>
           );

--- a/packages/nextjs/components/Search.tsx
+++ b/packages/nextjs/components/Search.tsx
@@ -75,7 +75,7 @@ export const Search: React.FC = () => {
   }, [closeMenu]);
 
   return (
-    <div className="mr-4 hidden sm:block">
+    <div className="mr-4 hidden md:block">
       <div {...getComboboxProps()}>
         <Input
           {...getInputProps({


### PR DESCRIPTION
Adding in a very simple active link indicator to the header links. Doesn't match up with designs, but we can worry about "pixel perfect" a bit later. Just wanted to get the indicator in there.

![image](https://user-images.githubusercontent.com/12721310/192625126-194fc475-8061-401a-85d8-38621c2170bc.png)
