### PR TITLE
add slicing option to sanity

### DIFF
--- a/packages/sanity/schemas/variant.ts
+++ b/packages/sanity/schemas/variant.ts
@@ -80,7 +80,17 @@ export default {
       title: "Size",
       type: "reference",
       to: [{ type: "size" }],
-      validation: (rule) => rule.required(),
+    },
+    {
+      name: "slicingOption",
+      title: "Slicing Option",
+      type: "array",
+      of: [
+        {
+          type: "reference",
+          to: [{ type: "size" }],
+        },
+      ],
     },
   ],
   preview: {


### PR DESCRIPTION
Quick sanity change to add an additional field for slicing option which can be a multi-select field used for filtering. Instead of re-using size, I wanted to introduce a new field so it doesn't break other people's work until I've had a chance to go fix the size references.
This also removes `size` from being required as it will be deleted in a subsequent PR.