### PR TITLE
Keep footer at bottom

### DIFF
--- a/packages/nextjs/components/Layout.tsx
+++ b/packages/nextjs/components/Layout.tsx
@@ -13,9 +13,11 @@ export const Layout: React.FC<Props> = ({ children }) => {
       <Head>
         <title>Formidable Boulangerie</title>
       </Head>
-      <Header />
-      <main className="w-full">{children}</main>
-      <Footer />
+      <div className="min-h-screen flex flex-col">
+        <Header />
+        <main className="flex-1">{children}</main>
+        <Footer />
+      </div>
     </>
   );
 };


### PR DESCRIPTION
Small fix for pages with shorter content to keep the footer _at least_ at the bottom of the first viewport's-worth of height.

![image](https://user-images.githubusercontent.com/12721310/193077456-0052d33c-772f-44fb-b350-809d9f0695c7.png)
