### PR TITLE
Update Variant Content Model

### DIFF
--- a/packages/sanity/schemas/product.ts
+++ b/packages/sanity/schemas/product.ts
@@ -51,13 +51,14 @@ export default {
       ],
     },
     {
-      name: "variants",
-      title: "Variants",
+      name: "productVariants",
+      title: "Product Variants",
       type: "array",
       of: [
         {
-          type: "reference",
-          to: [{ type: "variant" }],
+          name: "productVariant",
+          title: "Product Variant",
+          type: "productVariant",
         },
       ],
     },

--- a/packages/sanity/schemas/productVariant.ts
+++ b/packages/sanity/schemas/productVariant.ts
@@ -23,10 +23,10 @@ const isUniqueId = (value, context) => {
 };
 
 export default {
-  name: "variant",
-  title: "Variant",
+  name: "productVariant",
+  title: "Product Variant",
   description: "Variant of the product",
-  type: "document",
+  type: "object",
   icon: GrMultiple,
   fields: [
     {

--- a/packages/sanity/schemas/schema.ts
+++ b/packages/sanity/schemas/schema.ts
@@ -5,10 +5,10 @@ import category from "./category";
 import categoryImage from "./categoryImage";
 import description from "./description";
 import product from "./product";
-import variant from "./variant";
 import flavour from "./flavour";
 import style from "./style";
 import productImage from "./productImage";
+import productVariant from "./productVariant";
 
 // Then import schema types from any plugins that might expose them
 // Then we give our schema to the builder and provide the result to Sanity
@@ -23,7 +23,7 @@ export default createSchema({
     category,
     product,
     productImage,
-    variant,
+    productVariant,
     description,
     flavour,
     style,


### PR DESCRIPTION
I switched `Variant` from a reference field of document type to an `object` that is nested within `Product` - rather than being at the same level as `Product`

I attempted to migrate the existing variant data to the new field, but the script I had wasn't working quite right, and since there aren't that many I can add them back manually. Because the types are different, the data won't persist with this new field, unfortunately. 

fixes #161 