### PR TITLE
Fix variant type so tests pass

### DIFF
--- a/packages/nextjs/components/FeaturedList.tsx
+++ b/packages/nextjs/components/FeaturedList.tsx
@@ -27,14 +27,14 @@ export const FeaturedList = ({ items }: Props) => {
             to: {
               pathname: `/products/${item.slug?.current}`,
               query: {
-                variant: item.variants?.[0]?.slug?.current,
+                variant: item.productVariants?.[0]?.slug?.current,
               },
             },
             title: item.name ?? "",
-            price: item.variants?.[0]?.price ?? 0,
+            price: item.productVariants?.[0]?.price ?? 0,
             imageProps: {
-              src: item.variants?.[0]?.images?.[0] ?? "",
-              alt: item.variants?.[0]?.name ?? "",
+              src: item.productVariants?.[0]?.images?.[0] ?? "",
+              alt: item.productVariants?.[0]?.name ?? "",
               containerClassName: "aspect-square",
             },
           };

--- a/packages/nextjs/components/ImageCarousel/types.ts
+++ b/packages/nextjs/components/ImageCarousel/types.ts
@@ -1,7 +1,7 @@
 import { GetProductAndRecommendationsQuery } from "utils/generated/graphql";
 
 export type ProductVariantImage = NonNullable<
-  NonNullable<GetProductAndRecommendationsQuery["allProduct"][0]["variants"]>[0]
+  NonNullable<GetProductAndRecommendationsQuery["allProduct"][0]["productVariants"]>[0]
 >["images"];
 
 export type ImageCarouselProps = {

--- a/packages/nextjs/components/ProductPage/ProductVariantSelector.tsx
+++ b/packages/nextjs/components/ProductPage/ProductVariantSelector.tsx
@@ -4,23 +4,23 @@ import { Select } from "components/Select";
 import { H6 } from "components/Typography/H6";
 import { GetProductAndRecommendationsQuery } from "utils/generated/graphql";
 
-export type ProductVariants = GetProductAndRecommendationsQuery["allProduct"][0]["variants"];
+export type ProductVariants = GetProductAndRecommendationsQuery["allProduct"][0]["productVariants"];
 export type ProductVariant = NonNullable<ProductVariants>[0];
 
 interface Props {
-  variants: ProductVariants;
+  productVariants: ProductVariants;
   selectedVariant?: ProductVariant;
   onVariantChange: (slug?: string) => void;
 }
 
-export const ProductVariantSelector = ({ variants, selectedVariant, onVariantChange }: Props) => {
+export const ProductVariantSelector = ({ productVariants, selectedVariant, onVariantChange }: Props) => {
   const options = useMemo(
     () =>
-      variants?.map((variant) => ({
+      productVariants?.map((variant) => ({
         title: variant?.name ?? "",
         value: variant?.slug?.current ?? "",
       })),
-    [variants]
+    [productVariants]
   );
 
   if (!options?.length) {

--- a/packages/nextjs/components/ProductPage/StyleOptions.tsx
+++ b/packages/nextjs/components/ProductPage/StyleOptions.tsx
@@ -4,7 +4,7 @@ import { H6 } from "components/Typography/H6";
 import { GetProductAndRecommendationsQuery } from "utils/generated/graphql";
 
 interface Props {
-  options: NonNullable<NonNullable<GetProductAndRecommendationsQuery["allProduct"][0]["variants"]>[0]>["style"];
+  options: NonNullable<NonNullable<GetProductAndRecommendationsQuery["allProduct"][0]["productVariants"]>[0]>["style"];
   selectedStyle?: string;
   onChange: (slicing: string) => void;
 }

--- a/packages/nextjs/graphql.schema.json
+++ b/packages/nextjs/graphql.schema.json
@@ -1182,11 +1182,6 @@
             "kind": "OBJECT",
             "name": "Style",
             "ofType": null
-          },
-          {
-            "kind": "OBJECT",
-            "name": "Variant",
-            "ofType": null
           }
         ]
       },
@@ -2653,19 +2648,7 @@
             "deprecationReason": null
           },
           {
-            "name": "slug",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "Slug",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "variants",
+            "name": "productVariants",
             "description": null,
             "args": [],
             "type": {
@@ -2673,9 +2656,21 @@
               "name": null,
               "ofType": {
                 "kind": "OBJECT",
-                "name": "Variant",
+                "name": "ProductVariant",
                 "ofType": null
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slug",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Slug",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -3193,6 +3188,351 @@
       },
       {
         "kind": "OBJECT",
+        "name": "ProductVariant",
+        "description": null,
+        "fields": [
+          {
+            "name": "_key",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "descriptionRaw",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "JSON",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "flavour",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Flavour",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "images",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "ProductImage",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "msrp",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "price",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "Float",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slug",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "Slug",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "style",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "Style",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ProductVariantFilter",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_key",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "msrp",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "FloatFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "StringFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "price",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "FloatFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slug",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "SlugFilter",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "INPUT_OBJECT",
+        "name": "ProductVariantSorting",
+        "description": null,
+        "fields": null,
+        "inputFields": [
+          {
+            "name": "_key",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "_type",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "id",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "msrp",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "price",
+            "description": null,
+            "type": {
+              "kind": "ENUM",
+              "name": "SortOrder",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "slug",
+            "description": null,
+            "type": {
+              "kind": "INPUT_OBJECT",
+              "name": "SlugSorting",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "interfaces": null,
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
         "name": "RootQuery",
         "description": null,
         "fields": [
@@ -3423,35 +3763,6 @@
             "type": {
               "kind": "OBJECT",
               "name": "Style",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "Variant",
-            "description": null,
-            "args": [
-              {
-                "name": "id",
-                "description": "Variant document ID",
-                "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "ID",
-                    "ofType": null
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "OBJECT",
-              "name": "Variant",
               "ofType": null
             },
             "isDeprecated": false,
@@ -4097,87 +4408,6 @@
                   "ofType": {
                     "kind": "OBJECT",
                     "name": "Style",
-                    "ofType": null
-                  }
-                }
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "allVariant",
-            "description": null,
-            "args": [
-              {
-                "name": "limit",
-                "description": "Max documents to return",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "offset",
-                "description": "Offset at which to start returning documents from",
-                "type": {
-                  "kind": "SCALAR",
-                  "name": "Int",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "sort",
-                "description": null,
-                "type": {
-                  "kind": "LIST",
-                  "name": null,
-                  "ofType": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "INPUT_OBJECT",
-                      "name": "VariantSorting",
-                      "ofType": null
-                    }
-                  }
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              },
-              {
-                "name": "where",
-                "description": null,
-                "type": {
-                  "kind": "INPUT_OBJECT",
-                  "name": "VariantFilter",
-                  "ofType": null
-                },
-                "defaultValue": null,
-                "isDeprecated": false,
-                "deprecationReason": null
-              }
-            ],
-            "type": {
-              "kind": "NON_NULL",
-              "name": null,
-              "ofType": {
-                "kind": "LIST",
-                "name": null,
-                "ofType": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "OBJECT",
-                    "name": "Variant",
                     "ofType": null
                   }
                 }
@@ -8292,513 +8522,6 @@
           },
           {
             "name": "name",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "SortOrder",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "slug",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "SlugSorting",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "OBJECT",
-        "name": "Variant",
-        "description": null,
-        "fields": [
-          {
-            "name": "_createdAt",
-            "description": "Date the document was created",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "DateTime",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_id",
-            "description": "Document ID",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "ID",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_key",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_rev",
-            "description": "Current document revision",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_type",
-            "description": "Document type",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_updatedAt",
-            "description": "Date the document was last modified",
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "DateTime",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "descriptionRaw",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "JSON",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "flavour",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Flavour",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "images",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "ProductImage",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "msrp",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "name",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "String",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "price",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "SCALAR",
-              "name": "Float",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "slug",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "OBJECT",
-              "name": "Slug",
-              "ofType": null
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "style",
-            "description": null,
-            "args": [],
-            "type": {
-              "kind": "LIST",
-              "name": null,
-              "ofType": {
-                "kind": "OBJECT",
-                "name": "Style",
-                "ofType": null
-              }
-            },
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "inputFields": null,
-        "interfaces": [
-          {
-            "kind": "INTERFACE",
-            "name": "Document",
-            "ofType": null
-          }
-        ],
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "VariantFilter",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "_",
-            "description": "Apply filters on document level",
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "Sanity_DocumentFilter",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_createdAt",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "DatetimeFilter",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_id",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "IDFilter",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_key",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "StringFilter",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_rev",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "StringFilter",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_type",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "StringFilter",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_updatedAt",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "DatetimeFilter",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "StringFilter",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "msrp",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "FloatFilter",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "name",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "StringFilter",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "price",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "FloatFilter",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "slug",
-            "description": null,
-            "type": {
-              "kind": "INPUT_OBJECT",
-              "name": "SlugFilter",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          }
-        ],
-        "interfaces": null,
-        "enumValues": null,
-        "possibleTypes": null
-      },
-      {
-        "kind": "INPUT_OBJECT",
-        "name": "VariantSorting",
-        "description": null,
-        "fields": null,
-        "inputFields": [
-          {
-            "name": "_createdAt",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "SortOrder",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_id",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "SortOrder",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_key",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "SortOrder",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_rev",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "SortOrder",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_type",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "SortOrder",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "_updatedAt",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "SortOrder",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "id",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "SortOrder",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "msrp",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "SortOrder",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "name",
-            "description": null,
-            "type": {
-              "kind": "ENUM",
-              "name": "SortOrder",
-              "ofType": null
-            },
-            "defaultValue": null,
-            "isDeprecated": false,
-            "deprecationReason": null
-          },
-          {
-            "name": "price",
             "description": null,
             "type": {
               "kind": "ENUM",

--- a/packages/nextjs/mocks/factory/index.ts
+++ b/packages/nextjs/mocks/factory/index.ts
@@ -5,11 +5,11 @@ import type {
   Image,
   Product,
   ProductImage,
+  ProductVariant,
   SanityImageCrop,
   SanityImageHotspot,
   Slug,
   Style,
-  Variant,
 } from "utils/generated/graphql";
 import faker from "faker";
 
@@ -76,7 +76,9 @@ export class MockFactory {
       categories: [],
       descriptionRaw: this.descriptionRaw({}),
       images: [this.productImage({}, name, "small"), this.productImage({}, name, "large")],
-      variants: faker.random.arrayElements(variants).map((variant) => this.variant({ name: variant + " " + name })),
+      productVariants: faker.random
+        .arrayElements(variants)
+        .map((variant) => this.variant({ name: variant + " " + name })),
       ...data,
     };
     return result;
@@ -174,21 +176,20 @@ export class MockFactory {
     };
     return result;
   }
-  variant(data: Partial<Variant>): Variant {
+  variant(data: Partial<ProductVariant>): ProductVariant {
     const name = data.name || "";
     const msrp = data.msrp || faker.datatype.number({ min: 2, max: 10 });
     const price =
       data.price || faker.random.arrayElement([msrp, msrp, msrp, faker.datatype.number({ min: 2, max: msrp })]);
 
-    const result: FullData<Variant> = {
-      __typename: "Variant",
+    const result: FullData<ProductVariant> = {
+      __typename: "ProductVariant",
       _type: "variant",
-      _id: this.id("Variant"),
+      id: this.id("Variant"),
       name,
       slug: this.slug(name),
       images: [this.productImage({}, name, "small")],
       descriptionRaw: this.descriptionRaw({}),
-      id: faker.datatype.uuid(),
       flavour: [this.flavour({})],
       msrp,
       price,

--- a/packages/nextjs/pages/products/[slug].tsx
+++ b/packages/nextjs/pages/products/[slug].tsx
@@ -38,8 +38,8 @@ const ProductPage: NextPage = () => {
 
   const product = data?.allProduct[0];
   const selectedVariant =
-    (product?.variants || []).find((v) => v?.slug?.current && v.slug.current === query.variant) ||
-    product?.variants?.[0];
+    (product?.productVariants || []).find((v) => v?.slug?.current && v.slug.current === query.variant) ||
+    product?.productVariants?.[0];
 
   return (
     <React.Fragment>
@@ -133,7 +133,7 @@ const PageBody = ({ variant, product }: { product?: PDPProduct; variant?: PDPVar
           <BlockContent value={variant?.descriptionRaw} className="text-body-reg text-primary font-medium" />
           <hr className="border-t border-t-primary my-5" />
           <ProductVariantSelector
-            variants={product?.variants}
+            variants={product?.productVariants}
             selectedVariant={variant}
             onVariantChange={onVariantChange}
           />
@@ -154,7 +154,7 @@ const PageBody = ({ variant, product }: { product?: PDPProduct; variant?: PDPVar
 };
 
 type PDPProduct = GetProductAndRecommendationsQuery["allProduct"][number];
-type PDPVariant = NonNullable<GetProductAndRecommendationsQuery["allProduct"][number]["variants"]>[number];
+type PDPVariant = NonNullable<GetProductAndRecommendationsQuery["allProduct"][number]["productVariants"]>[number];
 
 export const getServerSideProps = (async ({ res, query }) => {
   const { client, ssrCache } = initializeUrql();
@@ -171,7 +171,7 @@ export const getServerSideProps = (async ({ res, query }) => {
 
   // Extract variant slugs to add to cache keys, in case any of those change.
   const variantSlugs: string[] = (
-    pageData?.data?.allProduct?.[0]?.variants?.map((v: any) => v?.slug?.current) || []
+    pageData?.data?.allProduct?.[0]?.productVariants?.map((v: any) => v?.slug?.current) || []
   ).filter(Boolean);
   cacheKeys.push(...variantSlugs.map((s) => `${SanityType.Variant}_${s}`));
   setCachingHeaders(res, cacheKeys);

--- a/packages/nextjs/pages/products/[slug].tsx
+++ b/packages/nextjs/pages/products/[slug].tsx
@@ -59,7 +59,7 @@ const ProductPage: NextPage = () => {
         <div className="container grid sm:grid-cols-2 md:grid-cols-4 gap-4">
           <H6 className="col-span-2 md:col-span-1">Related Products</H6>
           {data?.recommendations?.slice(0, 3).map((prod) => {
-            const variant = prod.variants?.[0];
+            const variant = prod.productVariants?.[0];
             const image = variant?.images?.[0];
             if (!variant || !image) return null;
 
@@ -68,7 +68,7 @@ const ProductPage: NextPage = () => {
                 <Product
                   // TODO: make the interface for Product more generic so it can take result from GQL also
                   item={{
-                    _id: variant._id ?? "",
+                    _id: variant.id ?? "",
                     slug: variant?.slug?.current || "",
                     productSlug: prod.slug?.current || "",
                     imageAlt: variant.name ?? "",
@@ -110,11 +110,11 @@ const PageBody = ({ variant, product }: { product?: PDPProduct; variant?: PDPVar
   };
 
   const onAddToCart = () => {
-    if (variant?._id) {
+    if (variant?.id) {
       // If the item is already in the cart allow user to click add to cart multiple times
-      const existingCartItem = cartItems.find((item) => item._id === variant._id);
+      const existingCartItem = cartItems.find((item) => item._id === variant.id);
 
-      updateCart(variant?._id, existingCartItem ? existingCartItem.qty + Number(quantity) : Number(quantity));
+      updateCart(variant?.id, existingCartItem ? existingCartItem.qty + Number(quantity) : Number(quantity));
     }
   };
 
@@ -133,7 +133,7 @@ const PageBody = ({ variant, product }: { product?: PDPProduct; variant?: PDPVar
           <BlockContent value={variant?.descriptionRaw} className="text-body-reg text-primary font-medium" />
           <hr className="border-t border-t-primary my-5" />
           <ProductVariantSelector
-            variants={product?.productVariants}
+            productVariants={product?.productVariants}
             selectedVariant={variant}
             onVariantChange={onVariantChange}
           />

--- a/packages/nextjs/pages/products/index.tsx
+++ b/packages/nextjs/pages/products/index.tsx
@@ -30,7 +30,7 @@ import { Pagination } from "components/Pagination";
 import { FadeInOut } from "components/FadeInOut";
 
 interface ProductsPageProps {
-  variants: PLPVariant[];
+  productVariants: PLPVariant[];
   itemCount: number;
   pageSize: number;
   pageCount: number;
@@ -41,14 +41,14 @@ interface ProductsPageProps {
 }
 
 const ProductsPage: NextPage<ProductsPageProps> = ({
-  variants,
+  productVariants,
   pageCount,
   currentPage,
   categoryFilters,
   flavourFilters,
   styleFilters,
 }) => {
-  const productNames = pluralize(variants.map((prod) => prod.name));
+  const productNames = pluralize(productVariants.map((prod) => prod.name));
   const { query } = useRouter();
 
   return (
@@ -73,7 +73,7 @@ const ProductsPage: NextPage<ProductsPageProps> = ({
 
             <div className="flex-1 order-1 md:order-2">
               <AnimatePresence mode="wait">
-                {variants.length > 0 && (
+                {productVariants.length > 0 && (
                   <FadeInOut
                     className={classNames(
                       "w-full grid grid-cols-2 sm:grid-cols-3 md:grid-cols-2 lg:grid-cols-3 gap-x-3 gap-y-9 mb-9",
@@ -81,24 +81,26 @@ const ProductsPage: NextPage<ProductsPageProps> = ({
                     )}
                     key={productNames}
                   >
-                    {variants.map((variant) => (
+                    {productVariants.map((variant) => (
                       <Product key={variant._id} item={variant} />
                     ))}
                     {/* Add padder items when on page > 1 so pagination bar isn't moving around */}
                     {+(query?.page || 1) > 1 &&
-                      Array.from({ length: 6 - variants.length })
+                      Array.from({ length: 6 - productVariants.length })
                         .fill(undefined)
                         .map((_, i) => <div key={i} className="invisible" />)}
                   </FadeInOut>
                 )}
 
-                {variants.length === 0 && (
+                {productVariants.length === 0 && (
                   <div className="flex-1 flex flex-col justify-center items-center">
                     <H6 className="text-center">No products found</H6>
                   </div>
                 )}
               </AnimatePresence>
-              {variants.length > 0 && <Pagination key="pagination" pageCount={pageCount} currentPage={currentPage} />}
+              {productVariants.length > 0 && (
+                <Pagination key="pagination" pageCount={pageCount} currentPage={currentPage} />
+              )}
             </div>
           </div>
         </div>
@@ -124,8 +126,8 @@ export const getServerSideProps = (async ({ query, res, resolvedUrl }) => {
   const pagination = getPaginationFromQuery(query);
 
   const result = await getFilteredPaginatedQuery<PLPVariantList>(GetAllFilteredVariants(filters, order), pagination);
-
-  const { variants, itemCount } = result;
+  console.log({ result });
+  const { productVariants, itemCount } = result;
   const { currentPage, pageSize } = pagination;
   const pageCount = Math.ceil(itemCount / pageSize);
 
@@ -150,7 +152,7 @@ export const getServerSideProps = (async ({ query, res, resolvedUrl }) => {
       categoryFilters,
       flavourFilters,
       styleFilters,
-      variants,
+      productVariants,
       itemCount,
       pageCount,
       pageSize,

--- a/packages/nextjs/pages/products/index.tsx
+++ b/packages/nextjs/pages/products/index.tsx
@@ -82,7 +82,7 @@ const ProductsPage: NextPage<ProductsPageProps> = ({
                     key={productNames}
                   >
                     {productVariants.map((variant) => (
-                      <Product key={variant._id} item={variant} />
+                      <Product key={variant.id} item={variant} />
                     ))}
                     {/* Add padder items when on page > 1 so pagination bar isn't moving around */}
                     {+(query?.page || 1) > 1 &&

--- a/packages/nextjs/pages/products/index.tsx
+++ b/packages/nextjs/pages/products/index.tsx
@@ -126,7 +126,7 @@ export const getServerSideProps = (async ({ query, res, resolvedUrl }) => {
   const pagination = getPaginationFromQuery(query);
 
   const result = await getFilteredPaginatedQuery<PLPVariantList>(GetAllFilteredVariants(filters, order), pagination);
-  console.log({ result });
+
   const { productVariants, itemCount } = result;
   const { currentPage, pageSize } = pagination;
   const pageCount = Math.ceil(itemCount / pageSize);

--- a/packages/nextjs/utils/generated/graphql-mock-types.ts
+++ b/packages/nextjs/utils/generated/graphql-mock-types.ts
@@ -350,8 +350,8 @@ export type Product = Document & {
   descriptionRaw?: Maybe<Scalars['JSON']>;
   images?: Maybe<Array<Maybe<ProductImage>>>;
   name?: Maybe<Scalars['String']>;
+  productVariants?: Maybe<Array<Maybe<ProductVariant>>>;
   slug?: Maybe<Slug>;
-  variants?: Maybe<Array<Maybe<Variant>>>;
 };
 
 export type ProductFilter = {
@@ -408,6 +408,41 @@ export type ProductSorting = {
   slug?: InputMaybe<SlugSorting>;
 };
 
+export type ProductVariant = {
+  __typename?: 'ProductVariant';
+  _key?: Maybe<Scalars['String']>;
+  _type?: Maybe<Scalars['String']>;
+  descriptionRaw?: Maybe<Scalars['JSON']>;
+  flavour?: Maybe<Array<Maybe<Flavour>>>;
+  id?: Maybe<Scalars['String']>;
+  images?: Maybe<Array<Maybe<ProductImage>>>;
+  msrp?: Maybe<Scalars['Float']>;
+  name?: Maybe<Scalars['String']>;
+  price?: Maybe<Scalars['Float']>;
+  slug?: Maybe<Slug>;
+  style?: Maybe<Array<Maybe<Style>>>;
+};
+
+export type ProductVariantFilter = {
+  _key?: InputMaybe<StringFilter>;
+  _type?: InputMaybe<StringFilter>;
+  id?: InputMaybe<StringFilter>;
+  msrp?: InputMaybe<FloatFilter>;
+  name?: InputMaybe<StringFilter>;
+  price?: InputMaybe<FloatFilter>;
+  slug?: InputMaybe<SlugFilter>;
+};
+
+export type ProductVariantSorting = {
+  _key?: InputMaybe<SortOrder>;
+  _type?: InputMaybe<SortOrder>;
+  id?: InputMaybe<SortOrder>;
+  msrp?: InputMaybe<SortOrder>;
+  name?: InputMaybe<SortOrder>;
+  price?: InputMaybe<SortOrder>;
+  slug?: InputMaybe<SlugSorting>;
+};
+
 export type RootQuery = {
   __typename?: 'RootQuery';
   Category?: Maybe<Category>;
@@ -418,7 +453,6 @@ export type RootQuery = {
   SanityFileAsset?: Maybe<SanityFileAsset>;
   SanityImageAsset?: Maybe<SanityImageAsset>;
   Style?: Maybe<Style>;
-  Variant?: Maybe<Variant>;
   allCategory: Array<Category>;
   allCategoryImage: Array<CategoryImage>;
   allDocument: Array<Document>;
@@ -427,7 +461,6 @@ export type RootQuery = {
   allSanityFileAsset: Array<SanityFileAsset>;
   allSanityImageAsset: Array<SanityImageAsset>;
   allStyle: Array<Style>;
-  allVariant: Array<Variant>;
 };
 
 
@@ -467,11 +500,6 @@ export type RootQuerySanityImageAssetArgs = {
 
 
 export type RootQueryStyleArgs = {
-  id: Scalars['ID'];
-};
-
-
-export type RootQueryVariantArgs = {
   id: Scalars['ID'];
 };
 
@@ -537,14 +565,6 @@ export type RootQueryAllStyleArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   sort?: InputMaybe<Array<StyleSorting>>;
   where?: InputMaybe<StyleFilter>;
-};
-
-
-export type RootQueryAllVariantArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-  sort?: InputMaybe<Array<VariantSorting>>;
-  where?: InputMaybe<VariantFilter>;
 };
 
 export type SanityAssetSourceData = {
@@ -1005,60 +1025,6 @@ export type StyleSorting = {
   slug?: InputMaybe<SlugSorting>;
 };
 
-export type Variant = Document & {
-  __typename?: 'Variant';
-  /** Date the document was created */
-  _createdAt?: Maybe<Scalars['DateTime']>;
-  /** Document ID */
-  _id?: Maybe<Scalars['ID']>;
-  _key?: Maybe<Scalars['String']>;
-  /** Current document revision */
-  _rev?: Maybe<Scalars['String']>;
-  /** Document type */
-  _type?: Maybe<Scalars['String']>;
-  /** Date the document was last modified */
-  _updatedAt?: Maybe<Scalars['DateTime']>;
-  descriptionRaw?: Maybe<Scalars['JSON']>;
-  flavour?: Maybe<Array<Maybe<Flavour>>>;
-  id?: Maybe<Scalars['String']>;
-  images?: Maybe<Array<Maybe<ProductImage>>>;
-  msrp?: Maybe<Scalars['Float']>;
-  name?: Maybe<Scalars['String']>;
-  price?: Maybe<Scalars['Float']>;
-  slug?: Maybe<Slug>;
-  style?: Maybe<Array<Maybe<Style>>>;
-};
-
-export type VariantFilter = {
-  /** Apply filters on document level */
-  _?: InputMaybe<Sanity_DocumentFilter>;
-  _createdAt?: InputMaybe<DatetimeFilter>;
-  _id?: InputMaybe<IdFilter>;
-  _key?: InputMaybe<StringFilter>;
-  _rev?: InputMaybe<StringFilter>;
-  _type?: InputMaybe<StringFilter>;
-  _updatedAt?: InputMaybe<DatetimeFilter>;
-  id?: InputMaybe<StringFilter>;
-  msrp?: InputMaybe<FloatFilter>;
-  name?: InputMaybe<StringFilter>;
-  price?: InputMaybe<FloatFilter>;
-  slug?: InputMaybe<SlugFilter>;
-};
-
-export type VariantSorting = {
-  _createdAt?: InputMaybe<SortOrder>;
-  _id?: InputMaybe<SortOrder>;
-  _key?: InputMaybe<SortOrder>;
-  _rev?: InputMaybe<SortOrder>;
-  _type?: InputMaybe<SortOrder>;
-  _updatedAt?: InputMaybe<SortOrder>;
-  id?: InputMaybe<SortOrder>;
-  msrp?: InputMaybe<SortOrder>;
-  name?: InputMaybe<SortOrder>;
-  price?: InputMaybe<SortOrder>;
-  slug?: InputMaybe<SlugSorting>;
-};
-
 export type GetCategoriesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -1072,19 +1038,19 @@ export type GetCategoriesSlugsQuery = { __typename?: 'RootQuery', allCategory: A
 export type GetProductsAndCategoriesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetProductsAndCategoriesQuery = { __typename?: 'RootQuery', allCategory: Array<{ __typename?: 'Category', _id?: string | null, name?: string | null, description?: string | null, slug?: { __typename?: 'Slug', current?: string | null } | null, images?: Array<{ __typename?: 'CategoryImage', name?: string | null, images?: { __typename?: 'Image', asset?: { __typename?: 'SanityImageAsset', url?: string | null } | null } | null } | null> | null }>, allProduct: Array<{ __typename?: 'Product', _id?: string | null, name?: string | null, slug?: { __typename?: 'Slug', current?: string | null } | null, images?: Array<{ __typename?: 'ProductImage', asset?: { __typename?: 'SanityImageAsset', _id?: string | null, url?: string | null } | null } | null> | null, variants?: Array<{ __typename?: 'Variant', price?: number | null, name?: string | null, slug?: { __typename?: 'Slug', current?: string | null } | null, images?: Array<{ __typename?: 'ProductImage', asset?: { __typename?: 'SanityImageAsset', _id?: string | null, url?: string | null } | null } | null> | null } | null> | null }> };
+export type GetProductsAndCategoriesQuery = { __typename?: 'RootQuery', allCategory: Array<{ __typename?: 'Category', _id?: string | null, name?: string | null, description?: string | null, slug?: { __typename?: 'Slug', current?: string | null } | null, images?: Array<{ __typename?: 'CategoryImage', name?: string | null, images?: { __typename?: 'Image', asset?: { __typename?: 'SanityImageAsset', url?: string | null } | null } | null } | null> | null }>, allProduct: Array<{ __typename?: 'Product', _id?: string | null, name?: string | null, slug?: { __typename?: 'Slug', current?: string | null } | null, images?: Array<{ __typename?: 'ProductImage', asset?: { __typename?: 'SanityImageAsset', _id?: string | null, url?: string | null } | null } | null> | null, productVariants?: Array<{ __typename?: 'ProductVariant', price?: number | null, name?: string | null, slug?: { __typename?: 'Slug', current?: string | null } | null, images?: Array<{ __typename?: 'ProductImage', asset?: { __typename?: 'SanityImageAsset', _id?: string | null, url?: string | null } | null } | null> | null } | null> | null }> };
 
 export type GetProductAndRecommendationsQueryVariables = Exact<{
   slug: Scalars['String'];
 }>;
 
 
-export type GetProductAndRecommendationsQuery = { __typename?: 'RootQuery', allProduct: Array<{ __typename?: 'Product', _id?: string | null, name?: string | null, categories?: Array<{ __typename?: 'Category', name?: string | null } | null> | null, slug?: { __typename?: 'Slug', current?: string | null } | null, variants?: Array<{ __typename?: 'Variant', _id?: string | null, id?: string | null, name?: string | null, descriptionRaw?: any | null, msrp?: number | null, price?: number | null, slug?: { __typename?: 'Slug', current?: string | null } | null, images?: Array<{ __typename?: 'ProductImage', name?: string | null, asset?: { __typename?: 'SanityImageAsset', _id?: string | null } | null } | null> | null, style?: Array<{ __typename?: 'Style', _id?: string | null, name?: string | null } | null> | null } | null> | null }>, recommendations: Array<{ __typename?: 'Product', _id?: string | null, name?: string | null, slug?: { __typename?: 'Slug', current?: string | null } | null, variants?: Array<{ __typename?: 'Variant', _id?: string | null, name?: string | null, price?: number | null, msrp?: number | null, slug?: { __typename?: 'Slug', current?: string | null } | null, images?: Array<{ __typename?: 'ProductImage', asset?: { __typename?: 'SanityImageAsset', url?: string | null } | null } | null> | null } | null> | null }> };
+export type GetProductAndRecommendationsQuery = { __typename?: 'RootQuery', allProduct: Array<{ __typename?: 'Product', _id?: string | null, name?: string | null, categories?: Array<{ __typename?: 'Category', name?: string | null } | null> | null, slug?: { __typename?: 'Slug', current?: string | null } | null, productVariants?: Array<{ __typename?: 'ProductVariant', id?: string | null, name?: string | null, descriptionRaw?: any | null, msrp?: number | null, price?: number | null, slug?: { __typename?: 'Slug', current?: string | null } | null, images?: Array<{ __typename?: 'ProductImage', name?: string | null, asset?: { __typename?: 'SanityImageAsset', _id?: string | null } | null } | null> | null, style?: Array<{ __typename?: 'Style', _id?: string | null, name?: string | null } | null> | null } | null> | null }>, recommendations: Array<{ __typename?: 'Product', _id?: string | null, name?: string | null, slug?: { __typename?: 'Slug', current?: string | null } | null, productVariants?: Array<{ __typename?: 'ProductVariant', id?: string | null, name?: string | null, price?: number | null, msrp?: number | null, slug?: { __typename?: 'Slug', current?: string | null } | null, images?: Array<{ __typename?: 'ProductImage', asset?: { __typename?: 'SanityImageAsset', url?: string | null } | null } | null> | null } | null> | null }> };
 
 export type GetProductsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetProductsQuery = { __typename?: 'RootQuery', allProduct: Array<{ __typename?: 'Product', _id?: string | null, name?: string | null, categories?: Array<{ __typename?: 'Category', name?: string | null } | null> | null, slug?: { __typename?: 'Slug', current?: string | null } | null, images?: Array<{ __typename?: 'ProductImage', name?: string | null, asset?: { __typename?: 'SanityImageAsset', url?: string | null } | null } | null> | null, variants?: Array<{ __typename?: 'Variant', name?: string | null, id?: string | null, msrp?: number | null, price?: number | null } | null> | null }> };
+export type GetProductsQuery = { __typename?: 'RootQuery', allProduct: Array<{ __typename?: 'Product', _id?: string | null, name?: string | null, categories?: Array<{ __typename?: 'Category', name?: string | null } | null> | null, slug?: { __typename?: 'Slug', current?: string | null } | null, images?: Array<{ __typename?: 'ProductImage', name?: string | null, asset?: { __typename?: 'SanityImageAsset', url?: string | null } | null } | null> | null, productVariants?: Array<{ __typename?: 'ProductVariant', name?: string | null, id?: string | null, msrp?: number | null, price?: number | null } | null> | null }> };
 
 export type GetProductsSlugsQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -1153,7 +1119,7 @@ export const GetProductsAndCategoriesDocument = gql`
         url
       }
     }
-    variants {
+    productVariants {
       price
       slug {
         current
@@ -1180,8 +1146,7 @@ export const GetProductAndRecommendationsDocument = gql`
     slug {
       current
     }
-    variants {
-      _id
+    productVariants {
       id
       name
       descriptionRaw
@@ -1208,8 +1173,8 @@ export const GetProductAndRecommendationsDocument = gql`
     slug {
       current
     }
-    variants {
-      _id
+    productVariants {
+      id
       name
       price
       msrp
@@ -1243,7 +1208,7 @@ export const GetProductsDocument = gql`
       }
       name
     }
-    variants {
+    productVariants {
       name
       id
       msrp

--- a/packages/nextjs/utils/generated/graphql.schema.graphql
+++ b/packages/nextjs/utils/generated/graphql.schema.graphql
@@ -394,8 +394,8 @@ type Product implements Document {
   descriptionRaw: JSON
   images: [ProductImage]
   name: String
+  productVariants: [ProductVariant]
   slug: Slug
-  variants: [Variant]
 }
 
 input ProductFilter {
@@ -451,6 +451,40 @@ input ProductSorting {
   slug: SlugSorting
 }
 
+type ProductVariant {
+  _key: String
+  _type: String
+  descriptionRaw: JSON
+  flavour: [Flavour]
+  id: String
+  images: [ProductImage]
+  msrp: Float
+  name: String
+  price: Float
+  slug: Slug
+  style: [Style]
+}
+
+input ProductVariantFilter {
+  _key: StringFilter
+  _type: StringFilter
+  id: StringFilter
+  msrp: FloatFilter
+  name: StringFilter
+  price: FloatFilter
+  slug: SlugFilter
+}
+
+input ProductVariantSorting {
+  _key: SortOrder
+  _type: SortOrder
+  id: SortOrder
+  msrp: SortOrder
+  name: SortOrder
+  price: SortOrder
+  slug: SlugSorting
+}
+
 type RootQuery {
   Category(
     """Category document ID"""
@@ -484,10 +518,6 @@ type RootQuery {
     """Style document ID"""
     id: ID!
   ): Style
-  Variant(
-    """Variant document ID"""
-    id: ID!
-  ): Variant
   allCategory(
     """Max documents to return"""
     limit: Int
@@ -560,15 +590,6 @@ type RootQuery {
     sort: [StyleSorting!]
     where: StyleFilter
   ): [Style!]!
-  allVariant(
-    """Max documents to return"""
-    limit: Int
-
-    """Offset at which to start returning documents from"""
-    offset: Int
-    sort: [VariantSorting!]
-    where: VariantFilter
-  ): [Variant!]!
 }
 
 type SanityAssetSourceData {
@@ -1037,62 +1058,5 @@ input StyleSorting {
   _type: SortOrder
   _updatedAt: SortOrder
   name: SortOrder
-  slug: SlugSorting
-}
-
-type Variant implements Document {
-  """Date the document was created"""
-  _createdAt: DateTime
-
-  """Document ID"""
-  _id: ID
-  _key: String
-
-  """Current document revision"""
-  _rev: String
-
-  """Document type"""
-  _type: String
-
-  """Date the document was last modified"""
-  _updatedAt: DateTime
-  descriptionRaw: JSON
-  flavour: [Flavour]
-  id: String
-  images: [ProductImage]
-  msrp: Float
-  name: String
-  price: Float
-  slug: Slug
-  style: [Style]
-}
-
-input VariantFilter {
-  """Apply filters on document level"""
-  _: Sanity_DocumentFilter
-  _createdAt: DatetimeFilter
-  _id: IDFilter
-  _key: StringFilter
-  _rev: StringFilter
-  _type: StringFilter
-  _updatedAt: DatetimeFilter
-  id: StringFilter
-  msrp: FloatFilter
-  name: StringFilter
-  price: FloatFilter
-  slug: SlugFilter
-}
-
-input VariantSorting {
-  _createdAt: SortOrder
-  _id: SortOrder
-  _key: SortOrder
-  _rev: SortOrder
-  _type: SortOrder
-  _updatedAt: SortOrder
-  id: SortOrder
-  msrp: SortOrder
-  name: SortOrder
-  price: SortOrder
   slug: SlugSorting
 }

--- a/packages/nextjs/utils/generated/graphql.ts
+++ b/packages/nextjs/utils/generated/graphql.ts
@@ -351,8 +351,8 @@ export type Product = Document & {
   descriptionRaw?: Maybe<Scalars['JSON']>;
   images?: Maybe<Array<Maybe<ProductImage>>>;
   name?: Maybe<Scalars['String']>;
+  productVariants?: Maybe<Array<Maybe<ProductVariant>>>;
   slug?: Maybe<Slug>;
-  variants?: Maybe<Array<Maybe<Variant>>>;
 };
 
 export type ProductFilter = {
@@ -409,6 +409,41 @@ export type ProductSorting = {
   slug?: InputMaybe<SlugSorting>;
 };
 
+export type ProductVariant = {
+  __typename?: 'ProductVariant';
+  _key?: Maybe<Scalars['String']>;
+  _type?: Maybe<Scalars['String']>;
+  descriptionRaw?: Maybe<Scalars['JSON']>;
+  flavour?: Maybe<Array<Maybe<Flavour>>>;
+  id?: Maybe<Scalars['String']>;
+  images?: Maybe<Array<Maybe<ProductImage>>>;
+  msrp?: Maybe<Scalars['Float']>;
+  name?: Maybe<Scalars['String']>;
+  price?: Maybe<Scalars['Float']>;
+  slug?: Maybe<Slug>;
+  style?: Maybe<Array<Maybe<Style>>>;
+};
+
+export type ProductVariantFilter = {
+  _key?: InputMaybe<StringFilter>;
+  _type?: InputMaybe<StringFilter>;
+  id?: InputMaybe<StringFilter>;
+  msrp?: InputMaybe<FloatFilter>;
+  name?: InputMaybe<StringFilter>;
+  price?: InputMaybe<FloatFilter>;
+  slug?: InputMaybe<SlugFilter>;
+};
+
+export type ProductVariantSorting = {
+  _key?: InputMaybe<SortOrder>;
+  _type?: InputMaybe<SortOrder>;
+  id?: InputMaybe<SortOrder>;
+  msrp?: InputMaybe<SortOrder>;
+  name?: InputMaybe<SortOrder>;
+  price?: InputMaybe<SortOrder>;
+  slug?: InputMaybe<SlugSorting>;
+};
+
 export type RootQuery = {
   __typename?: 'RootQuery';
   Category?: Maybe<Category>;
@@ -419,7 +454,6 @@ export type RootQuery = {
   SanityFileAsset?: Maybe<SanityFileAsset>;
   SanityImageAsset?: Maybe<SanityImageAsset>;
   Style?: Maybe<Style>;
-  Variant?: Maybe<Variant>;
   allCategory: Array<Category>;
   allCategoryImage: Array<CategoryImage>;
   allDocument: Array<Document>;
@@ -428,7 +462,6 @@ export type RootQuery = {
   allSanityFileAsset: Array<SanityFileAsset>;
   allSanityImageAsset: Array<SanityImageAsset>;
   allStyle: Array<Style>;
-  allVariant: Array<Variant>;
 };
 
 
@@ -468,11 +501,6 @@ export type RootQuerySanityImageAssetArgs = {
 
 
 export type RootQueryStyleArgs = {
-  id: Scalars['ID'];
-};
-
-
-export type RootQueryVariantArgs = {
   id: Scalars['ID'];
 };
 
@@ -538,14 +566,6 @@ export type RootQueryAllStyleArgs = {
   offset?: InputMaybe<Scalars['Int']>;
   sort?: InputMaybe<Array<StyleSorting>>;
   where?: InputMaybe<StyleFilter>;
-};
-
-
-export type RootQueryAllVariantArgs = {
-  limit?: InputMaybe<Scalars['Int']>;
-  offset?: InputMaybe<Scalars['Int']>;
-  sort?: InputMaybe<Array<VariantSorting>>;
-  where?: InputMaybe<VariantFilter>;
 };
 
 export type SanityAssetSourceData = {
@@ -1006,60 +1026,6 @@ export type StyleSorting = {
   slug?: InputMaybe<SlugSorting>;
 };
 
-export type Variant = Document & {
-  __typename?: 'Variant';
-  /** Date the document was created */
-  _createdAt?: Maybe<Scalars['DateTime']>;
-  /** Document ID */
-  _id?: Maybe<Scalars['ID']>;
-  _key?: Maybe<Scalars['String']>;
-  /** Current document revision */
-  _rev?: Maybe<Scalars['String']>;
-  /** Document type */
-  _type?: Maybe<Scalars['String']>;
-  /** Date the document was last modified */
-  _updatedAt?: Maybe<Scalars['DateTime']>;
-  descriptionRaw?: Maybe<Scalars['JSON']>;
-  flavour?: Maybe<Array<Maybe<Flavour>>>;
-  id?: Maybe<Scalars['String']>;
-  images?: Maybe<Array<Maybe<ProductImage>>>;
-  msrp?: Maybe<Scalars['Float']>;
-  name?: Maybe<Scalars['String']>;
-  price?: Maybe<Scalars['Float']>;
-  slug?: Maybe<Slug>;
-  style?: Maybe<Array<Maybe<Style>>>;
-};
-
-export type VariantFilter = {
-  /** Apply filters on document level */
-  _?: InputMaybe<Sanity_DocumentFilter>;
-  _createdAt?: InputMaybe<DatetimeFilter>;
-  _id?: InputMaybe<IdFilter>;
-  _key?: InputMaybe<StringFilter>;
-  _rev?: InputMaybe<StringFilter>;
-  _type?: InputMaybe<StringFilter>;
-  _updatedAt?: InputMaybe<DatetimeFilter>;
-  id?: InputMaybe<StringFilter>;
-  msrp?: InputMaybe<FloatFilter>;
-  name?: InputMaybe<StringFilter>;
-  price?: InputMaybe<FloatFilter>;
-  slug?: InputMaybe<SlugFilter>;
-};
-
-export type VariantSorting = {
-  _createdAt?: InputMaybe<SortOrder>;
-  _id?: InputMaybe<SortOrder>;
-  _key?: InputMaybe<SortOrder>;
-  _rev?: InputMaybe<SortOrder>;
-  _type?: InputMaybe<SortOrder>;
-  _updatedAt?: InputMaybe<SortOrder>;
-  id?: InputMaybe<SortOrder>;
-  msrp?: InputMaybe<SortOrder>;
-  name?: InputMaybe<SortOrder>;
-  price?: InputMaybe<SortOrder>;
-  slug?: InputMaybe<SlugSorting>;
-};
-
 export type GetCategoriesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -1073,19 +1039,19 @@ export type GetCategoriesSlugsQuery = { __typename?: 'RootQuery', allCategory: A
 export type GetProductsAndCategoriesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetProductsAndCategoriesQuery = { __typename?: 'RootQuery', allCategory: Array<{ __typename?: 'Category', _id?: string | null, name?: string | null, description?: string | null, slug?: { __typename?: 'Slug', current?: string | null } | null, images?: Array<{ __typename?: 'CategoryImage', name?: string | null, images?: { __typename?: 'Image', asset?: { __typename?: 'SanityImageAsset', url?: string | null } | null } | null } | null> | null }>, allProduct: Array<{ __typename?: 'Product', _id?: string | null, name?: string | null, slug?: { __typename?: 'Slug', current?: string | null } | null, images?: Array<{ __typename?: 'ProductImage', asset?: { __typename?: 'SanityImageAsset', _id?: string | null, url?: string | null } | null } | null> | null, variants?: Array<{ __typename?: 'Variant', price?: number | null, name?: string | null, slug?: { __typename?: 'Slug', current?: string | null } | null, images?: Array<{ __typename?: 'ProductImage', asset?: { __typename?: 'SanityImageAsset', _id?: string | null, url?: string | null } | null } | null> | null } | null> | null }> };
+export type GetProductsAndCategoriesQuery = { __typename?: 'RootQuery', allCategory: Array<{ __typename?: 'Category', _id?: string | null, name?: string | null, description?: string | null, slug?: { __typename?: 'Slug', current?: string | null } | null, images?: Array<{ __typename?: 'CategoryImage', name?: string | null, images?: { __typename?: 'Image', asset?: { __typename?: 'SanityImageAsset', url?: string | null } | null } | null } | null> | null }>, allProduct: Array<{ __typename?: 'Product', _id?: string | null, name?: string | null, slug?: { __typename?: 'Slug', current?: string | null } | null, images?: Array<{ __typename?: 'ProductImage', asset?: { __typename?: 'SanityImageAsset', _id?: string | null, url?: string | null } | null } | null> | null, productVariants?: Array<{ __typename?: 'ProductVariant', price?: number | null, name?: string | null, slug?: { __typename?: 'Slug', current?: string | null } | null, images?: Array<{ __typename?: 'ProductImage', asset?: { __typename?: 'SanityImageAsset', _id?: string | null, url?: string | null } | null } | null> | null } | null> | null }> };
 
 export type GetProductAndRecommendationsQueryVariables = Exact<{
   slug: Scalars['String'];
 }>;
 
 
-export type GetProductAndRecommendationsQuery = { __typename?: 'RootQuery', allProduct: Array<{ __typename?: 'Product', _id?: string | null, name?: string | null, categories?: Array<{ __typename?: 'Category', name?: string | null } | null> | null, slug?: { __typename?: 'Slug', current?: string | null } | null, variants?: Array<{ __typename?: 'Variant', _id?: string | null, id?: string | null, name?: string | null, descriptionRaw?: any | null, msrp?: number | null, price?: number | null, slug?: { __typename?: 'Slug', current?: string | null } | null, images?: Array<{ __typename?: 'ProductImage', name?: string | null, asset?: { __typename?: 'SanityImageAsset', _id?: string | null } | null } | null> | null, style?: Array<{ __typename?: 'Style', _id?: string | null, name?: string | null } | null> | null } | null> | null }>, recommendations: Array<{ __typename?: 'Product', _id?: string | null, name?: string | null, slug?: { __typename?: 'Slug', current?: string | null } | null, variants?: Array<{ __typename?: 'Variant', _id?: string | null, name?: string | null, price?: number | null, msrp?: number | null, slug?: { __typename?: 'Slug', current?: string | null } | null, images?: Array<{ __typename?: 'ProductImage', asset?: { __typename?: 'SanityImageAsset', url?: string | null } | null } | null> | null } | null> | null }> };
+export type GetProductAndRecommendationsQuery = { __typename?: 'RootQuery', allProduct: Array<{ __typename?: 'Product', _id?: string | null, name?: string | null, categories?: Array<{ __typename?: 'Category', name?: string | null } | null> | null, slug?: { __typename?: 'Slug', current?: string | null } | null, productVariants?: Array<{ __typename?: 'ProductVariant', id?: string | null, name?: string | null, descriptionRaw?: any | null, msrp?: number | null, price?: number | null, slug?: { __typename?: 'Slug', current?: string | null } | null, images?: Array<{ __typename?: 'ProductImage', name?: string | null, asset?: { __typename?: 'SanityImageAsset', _id?: string | null } | null } | null> | null, style?: Array<{ __typename?: 'Style', _id?: string | null, name?: string | null } | null> | null } | null> | null }>, recommendations: Array<{ __typename?: 'Product', _id?: string | null, name?: string | null, slug?: { __typename?: 'Slug', current?: string | null } | null, productVariants?: Array<{ __typename?: 'ProductVariant', id?: string | null, name?: string | null, price?: number | null, msrp?: number | null, slug?: { __typename?: 'Slug', current?: string | null } | null, images?: Array<{ __typename?: 'ProductImage', asset?: { __typename?: 'SanityImageAsset', url?: string | null } | null } | null> | null } | null> | null }> };
 
 export type GetProductsQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type GetProductsQuery = { __typename?: 'RootQuery', allProduct: Array<{ __typename?: 'Product', _id?: string | null, name?: string | null, categories?: Array<{ __typename?: 'Category', name?: string | null } | null> | null, slug?: { __typename?: 'Slug', current?: string | null } | null, images?: Array<{ __typename?: 'ProductImage', name?: string | null, asset?: { __typename?: 'SanityImageAsset', url?: string | null } | null } | null> | null, variants?: Array<{ __typename?: 'Variant', name?: string | null, id?: string | null, msrp?: number | null, price?: number | null } | null> | null }> };
+export type GetProductsQuery = { __typename?: 'RootQuery', allProduct: Array<{ __typename?: 'Product', _id?: string | null, name?: string | null, categories?: Array<{ __typename?: 'Category', name?: string | null } | null> | null, slug?: { __typename?: 'Slug', current?: string | null } | null, images?: Array<{ __typename?: 'ProductImage', name?: string | null, asset?: { __typename?: 'SanityImageAsset', url?: string | null } | null } | null> | null, productVariants?: Array<{ __typename?: 'ProductVariant', name?: string | null, id?: string | null, msrp?: number | null, price?: number | null } | null> | null }> };
 
 export type GetProductsSlugsQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -1162,7 +1128,7 @@ export const GetProductsAndCategoriesDocument = gql`
         url
       }
     }
-    variants {
+    productVariants {
       price
       slug {
         current
@@ -1193,8 +1159,7 @@ export const GetProductAndRecommendationsDocument = gql`
     slug {
       current
     }
-    variants {
-      _id
+    productVariants {
       id
       name
       descriptionRaw
@@ -1221,8 +1186,8 @@ export const GetProductAndRecommendationsDocument = gql`
     slug {
       current
     }
-    variants {
-      _id
+    productVariants {
+      id
       name
       price
       msrp
@@ -1260,7 +1225,7 @@ export const GetProductsDocument = gql`
       }
       name
     }
-    variants {
+    productVariants {
       name
       id
       msrp

--- a/packages/nextjs/utils/getFilteredPaginatedQuery.ts
+++ b/packages/nextjs/utils/getFilteredPaginatedQuery.ts
@@ -4,14 +4,15 @@ import { sanityClient } from "./sanityClient";
 export function GetAllFilteredVariants(filters = "", order = "") {
   return groq`
   {
-    'variants': *[_type == "variant"]${filters} {
-      _id, name, msrp, price,
-      'slug': slug.current,
+    'productVariants': *[_type == "product"]${filters} {
+      _id, name,
+      "msrp": productVariants[0].msrp,
+      "price": productVariants[0].price,
+      'productSlug': slug.current,
       'imageAlt': name,
-      'images': images[0],
-      'productSlug': *[_type == "product"][references(^._id)][0].slug.current
+      "images": images[0],
     } ${order} [$offsetPage...$limit],
-    'itemCount': count(*[_type == "variant"]${filters}),
+    'itemCount': count(*[_type == "product"]${filters}),
   }`;
 }
 

--- a/packages/nextjs/utils/getFilteredPaginatedQuery.ts
+++ b/packages/nextjs/utils/getFilteredPaginatedQuery.ts
@@ -4,10 +4,8 @@ import { sanityClient } from "./sanityClient";
 export function GetAllFilteredVariants(filters = "", order = "") {
   return groq`
   {
-    'productVariants': *[_type == "product"]${filters} {
-      _id, name,
-      "msrp": productVariants[0].msrp,
-      "price": productVariants[0].price,
+    'productVariants': *[_type == "product"].productVariants[]${filters} {
+      id, name, msrp, price,
       'productSlug': slug.current,
       'imageAlt': name,
       "images": images[0],

--- a/packages/nextjs/utils/getFiltersFromQuery.ts
+++ b/packages/nextjs/utils/getFiltersFromQuery.ts
@@ -1,5 +1,5 @@
-import { FilterGroupParams, getFilterGroups } from "utils/filters";
 import { ParsedUrlQuery } from "querystring";
+import { FilterGroupParams, getFilterGroups } from "utils/filters";
 
 export const getFiltersFromQuery = (
   query: ParsedUrlQuery,

--- a/packages/nextjs/utils/graphql/getProductAndCategories.graphql
+++ b/packages/nextjs/utils/graphql/getProductAndCategories.graphql
@@ -27,7 +27,7 @@ query getProductsAndCategories {
         url
       }
     }
-    variants {
+    productVariants {
       price
       slug {
         current

--- a/packages/nextjs/utils/graphql/getProductAndRecommendations.graphql
+++ b/packages/nextjs/utils/graphql/getProductAndRecommendations.graphql
@@ -8,8 +8,7 @@ query getProductAndRecommendations($slug: String!) {
     slug {
       current
     }
-    variants {
-      _id
+    productVariants {
       id
       name
       descriptionRaw
@@ -36,8 +35,8 @@ query getProductAndRecommendations($slug: String!) {
     slug {
       current
     }
-    variants {
-      _id
+    productVariants {
+      id
       name
       price
       msrp

--- a/packages/nextjs/utils/graphql/getProducts.graphql
+++ b/packages/nextjs/utils/graphql/getProducts.graphql
@@ -14,7 +14,7 @@ query getProducts {
       }
       name
     }
-    variants {
+    productVariants {
       name
       id
       msrp

--- a/packages/nextjs/utils/groqTypes/ProductList.ts
+++ b/packages/nextjs/utils/groqTypes/ProductList.ts
@@ -1,5 +1,5 @@
 export interface PLPVariant {
-  _id: string;
+  id: string;
   slug: string;
   name: string;
   msrp: number;

--- a/packages/nextjs/utils/groqTypes/ProductList.ts
+++ b/packages/nextjs/utils/groqTypes/ProductList.ts
@@ -10,7 +10,7 @@ export interface PLPVariant {
 }
 
 export interface PLPVariantList {
-  variants: PLPVariant[];
+  productVariants: PLPVariant[];
   itemCount: number;
 }
 

--- a/packages/sanity/schemas/schema.ts
+++ b/packages/sanity/schemas/schema.ts
@@ -8,7 +8,7 @@ import product from "./product";
 import flavour from "./flavour";
 import style from "./style";
 import productImage from "./productImage";
-import variant from "./productVariant";
+import productVariant from "./productVariant";
 
 // Then import schema types from any plugins that might expose them
 // Then we give our schema to the builder and provide the result to Sanity
@@ -23,7 +23,7 @@ export default createSchema({
     category,
     product,
     productImage,
-    variant,
+    productVariant,
     description,
     flavour,
     style,

--- a/packages/sanity/schemas/schema.ts
+++ b/packages/sanity/schemas/schema.ts
@@ -8,7 +8,7 @@ import product from "./product";
 import flavour from "./flavour";
 import style from "./style";
 import productImage from "./productImage";
-import productVariant from "./productVariant";
+import variant from "./productVariant";
 
 // Then import schema types from any plugins that might expose them
 // Then we give our schema to the builder and provide the result to Sanity
@@ -23,7 +23,7 @@ export default createSchema({
     category,
     product,
     productImage,
-    productVariant,
+    variant,
     description,
     flavour,
     style,

--- a/packages/sanity/schemas/variant.ts
+++ b/packages/sanity/schemas/variant.ts
@@ -1,0 +1,120 @@
+import { GrMultiple } from "react-icons/gr";
+import groq from "groq";
+import client from "part:@sanity/base/client";
+
+const isUniqueId = (value, context) => {
+  const { document } = context;
+
+  const id = document._id.replace(/^drafts\./, "");
+
+  const params = {
+    draft: `drafts.${id}`,
+    published: id,
+    id: value,
+  };
+
+  const query = groq`!defined(*[
+    _type == 'variant' &&
+    !(_id in [$draft, $published]) &&
+    id == $id
+  ][0]._id)`;
+
+  return client.fetch(query, params);
+};
+
+export default {
+  name: "variant",
+  title: "Variant",
+  description: "Variant of the product",
+  type: "document",
+  icon: GrMultiple,
+  fields: [
+    {
+      name: "name",
+      title: "Name",
+      type: "string",
+      validation: (rule) => rule.required(),
+    },
+    {
+      name: "slug",
+      title: "Slug",
+      type: "slug",
+      validation: (rule) => rule.required(),
+      options: {
+        source: "name",
+        maxLength: 200,
+        slugify: (input: string) => input.toLowerCase().replace(/\s+/g, "-").slice(0, 200),
+      },
+    },
+    {
+      name: "description",
+      title: "Description",
+      type: "description",
+    },
+    {
+      name: "id",
+      title: "ID",
+      type: "string",
+      validation: (rule) =>
+        rule.custom(async (value, context) => {
+          if (!value) return "ID is required";
+          const isUnique = await isUniqueId(value, context);
+          if (!isUnique) return "ID is not unique";
+          return true;
+        }),
+    },
+    {
+      name: "msrp",
+      title: "MSRP",
+      type: "number",
+      validation: (rule) => rule.required().positive(),
+    },
+    {
+      name: "price",
+      title: "Price",
+      type: "number",
+      validation: (rule) => rule.required().positive(),
+    },
+    {
+      name: "images",
+      title: "Images",
+      type: "array",
+      of: [
+        {
+          name: "productImage",
+          title: "Product Image",
+          type: "productImage",
+        },
+      ],
+    },
+    {
+      name: "flavour",
+      title: "Flavour",
+      type: "array",
+      of: [
+        {
+          type: "reference",
+          to: [{ type: "flavour" }],
+        },
+      ],
+    },
+    {
+      name: "style",
+      title: "Style (options)",
+      type: "array",
+      of: [
+        {
+          type: "reference",
+          to: [{ type: "style" }],
+        },
+      ],
+    },
+  ],
+  preview: {
+    select: {
+      title: "name",
+      media: "images.0.asset",
+      subtitle: "style.name",
+    },
+  },
+};

--- a/packages/tests-e2e/e2e-tests/product.cy.ts
+++ b/packages/tests-e2e/e2e-tests/product.cy.ts
@@ -6,7 +6,7 @@ describe("when I visit the Product Details Page", () => {
     // Find a product to test:
     cy.visit("/products");
     cy.getServerSideProps("/products").then((props) => {
-      const product = props.variants[0];
+      const product = props.productVariants[0];
       cy.visit(`/products/${product.productSlug}`);
     });
   });
@@ -26,7 +26,7 @@ describe("when I visit the Product Details Page", () => {
   it("I see the item's price", () => {
     cy.getServerSideProps("/products/[slug]").then((data) => {
       const product = data.allProduct[0];
-      const variant = product.variants![0]!;
+      const variant = product.productVariants![0]!;
       cy.findAllByText(/\$\d+\.\d\d/)
         .should("exist")
         .then((price) => {

--- a/packages/tests-e2e/e2e-tests/products.cy.ts
+++ b/packages/tests-e2e/e2e-tests/products.cy.ts
@@ -1,6 +1,6 @@
 import { generateMockData } from "mocks/msw/db/mock-data";
 import type { PageDataTypes } from "../cypress/support/commands/getServerSideProps";
-import { mockOnly } from '../utils/real-or-mock';
+import { mockOnly } from "../utils/real-or-mock";
 
 describe("when I visit the products page", () => {
   mockOnly.before(() => {
@@ -35,7 +35,7 @@ describe("when I visit the products page", () => {
     const EXPECTED_ITEMS_MINIMUM = 10;
 
     it("I see 6 products", () => {
-      expect(pageProps.variants.length).to.equal(
+      expect(pageProps.productVariants.length).to.equal(
         EXPECTED_ITEMS_PER_PAGE,
         `there should be ${EXPECTED_ITEMS_PER_PAGE} items on this page`
       );
@@ -44,7 +44,7 @@ describe("when I visit the products page", () => {
         `there should be at least ${EXPECTED_ITEMS_MINIMUM} items`
       );
 
-      pageProps.variants.forEach((variant) => {
+      pageProps.productVariants.forEach((variant) => {
         cy.findByText(variant.name).should("exist");
       });
     });


### PR DESCRIPTION
This fix allows the tests to pass, but there is more that needs to be done to ensure the rest of the site loads the products in correctly.

We were using `variants` to represent all products, so when I moved them to live within a `product` document type and not next to it, the way we access all variants broke. 

I'm going to keep working on updating the rest of the queries and manually update the data