### PR TITLE
sanity v3 - sanity deploy graphql build error

### DIFF
--- a/packages/sanity/sanity.cli.ts
+++ b/packages/sanity/sanity.cli.ts
@@ -5,10 +5,4 @@ export default defineCliConfig({
     projectId: "5bsv02jj",
     dataset: "production",
   },
-  graphql: [
-    {
-      playground: true,
-      workspace: "production",
-    },
-  ],
 });


### PR DESCRIPTION
fixed an issue with deploying the graphql api. running `sanity deploy graphql` should no longer fail during build