### PR TITLE
187 Add filter count to the filters button on smaller screen sizes

### DIFF
--- a/packages/nextjs/utils/getFiltersCount.ts
+++ b/packages/nextjs/utils/getFiltersCount.ts
@@ -17,10 +17,10 @@ export const getFiltersCount = (query: ParsedUrlQuery) => {
   }, 0);
 
   return total;
-}
+};
 
 export const useGetFiltersCount = () => {
   const router = useRouter();
-  
+
   return getFiltersCount(router.query);
 };

--- a/packages/nextjs/utils/getFiltersCount.ts
+++ b/packages/nextjs/utils/getFiltersCount.ts
@@ -1,0 +1,26 @@
+import { useRouter } from "next/router";
+import { ParsedUrlQuery } from "querystring";
+import type { FilterGroup } from "./filters";
+import { getFilterGroups } from "./filters";
+
+export const getFiltersCount = (query: ParsedUrlQuery) => {
+  const filters = getFilterGroups();
+
+  const total = filters.reduce((acc: number, { label, value }: FilterGroup) => {
+    const selectedFilters = query[value];
+    const elements = selectedFilters?.length ?? 0;
+
+    // if a single element is selected, type would be a string instead of an array.
+    const totalFilters = typeof selectedFilters === "string" ? (elements > 0 ? 1 : 0) : elements;
+
+    return (acc = acc + totalFilters);
+  }, 0);
+
+  return total;
+}
+
+export const useGetFiltersCount = () => {
+  const router = useRouter();
+  
+  return getFiltersCount(router.query);
+};

--- a/packages/nextjs/views/ModalFiltersMobile.tsx
+++ b/packages/nextjs/views/ModalFiltersMobile.tsx
@@ -2,7 +2,6 @@ import { Button } from "components/Button";
 import { Modal } from "components/Modal";
 import { ProductFilters } from "components/ProductFilters/ProductFilters";
 import React from "react";
-import { useGetFiltersCount } from "utils/getFiltersCount";
 import { CategoryFilterItem, FlavourFilterItem, StyleFilterItem } from "utils/groqTypes/ProductList";
 
 interface ModalFiltersMobileProps {
@@ -20,8 +19,6 @@ export const ModalFiltersMobile: React.FC<ModalFiltersMobileProps> = ({
   categoryFilters,
   onClose,
 }) => {
-  const total = useGetFiltersCount();
-
   return (
     <Modal className="w-full h-full min-h-[844px]" isOpen={isOpen} onClose={onClose}>
       <div className="w-full flex flex-col p-5 pt-10">
@@ -36,7 +33,7 @@ export const ModalFiltersMobile: React.FC<ModalFiltersMobileProps> = ({
             className="w-full rounded-2xl font-semibold justify-center"
             onClick={() => onClose(false)}
           >
-            View results {total > 0 ? `(${total})` : ""}
+            View results
           </Button>
         </div>
       </div>

--- a/packages/nextjs/views/ModalFiltersMobile.tsx
+++ b/packages/nextjs/views/ModalFiltersMobile.tsx
@@ -2,6 +2,7 @@ import { Button } from "components/Button";
 import { Modal } from "components/Modal";
 import { ProductFilters } from "components/ProductFilters/ProductFilters";
 import React from "react";
+import { useGetFiltersCount } from "utils/getFiltersCount";
 import { CategoryFilterItem, FlavourFilterItem, StyleFilterItem } from "utils/groqTypes/ProductList";
 
 interface ModalFiltersMobileProps {
@@ -19,6 +20,8 @@ export const ModalFiltersMobile: React.FC<ModalFiltersMobileProps> = ({
   categoryFilters,
   onClose,
 }) => {
+  const total = useGetFiltersCount();
+
   return (
     <Modal className="w-full h-full min-h-[844px]" isOpen={isOpen} onClose={onClose}>
       <div className="w-full flex flex-col p-5 pt-10">
@@ -33,7 +36,7 @@ export const ModalFiltersMobile: React.FC<ModalFiltersMobileProps> = ({
             className="w-full rounded-2xl font-semibold justify-center"
             onClick={() => onClose(false)}
           >
-            View results
+            View results {total > 0 ? `(${total})` : ""}
           </Button>
         </div>
       </div>

--- a/packages/nextjs/views/SortAndFiltersToolbarMobile.tsx
+++ b/packages/nextjs/views/SortAndFiltersToolbarMobile.tsx
@@ -2,15 +2,18 @@ import { Button } from "components/Button";
 import { ProductSort } from "components/ProductSort";
 import React from "react";
 import { MdOutlineFilterList } from "react-icons/md";
+import { useGetFiltersCount } from "utils/getFiltersCount";
 
 interface SortAndFiltersToolbarMobileProps {
   onFiltersClick?: React.MouseEventHandler;
 }
 
 export const SortAndFiltersToolbarMobile: React.FC<SortAndFiltersToolbarMobileProps> = ({ onFiltersClick }) => {
+  const total = useGetFiltersCount();
+
   return (
     <div className="my-6 mb-8 w-full inline-flex items-end justify-between md:hidden">
-      <ProductSort showTitle as="select" selectClassName="w-44 mr-2" />
+      <ProductSort showTitle as="select" selectClassName="w-40 mr-1" />
 
       <Button
         title="Open filters"
@@ -19,7 +22,7 @@ export const SortAndFiltersToolbarMobile: React.FC<SortAndFiltersToolbarMobilePr
         leftIcon={<MdOutlineFilterList className="w-5 h-5" />}
         onClick={onFiltersClick}
       >
-        Filters
+        Filters {total > 0 ? `(${total})` : ""}
       </Button>
     </div>
   );


### PR DESCRIPTION
At the beginning i was trying to change the filters checkbox behavior and add a new context to manage the selected filters count.

I ended up creating a method to get the selected filters from the query string.


## Screenshots

### Before
<img width="397" alt="Screenshot 2023-02-13 at 15 26 00" src="https://user-images.githubusercontent.com/186492/218578246-ff2525c7-14cc-4cb4-b003-a0baeec95f3e.png">

<img width="391" alt="Screenshot 2023-02-13 at 15 26 11" src="https://user-images.githubusercontent.com/186492/218578261-e226a0f9-5376-4232-a6a3-22ad3af74a8d.png">


### After

<img width="395" alt="Screenshot 2023-02-13 at 14 58 18" src="https://user-images.githubusercontent.com/186492/218578345-07c4feef-0219-4b32-aff1-070856940e16.png">

<img width="395" alt="Screenshot 2023-02-13 at 14 58 30" src="https://user-images.githubusercontent.com/186492/218578373-8d040a3c-5cb6-473d-9fc8-405d5be48455.png">

