### PR TITLE
Convert filters to groqd

### DIFF
--- a/packages/nextjs/components/Product.tsx
+++ b/packages/nextjs/components/Product.tsx
@@ -3,7 +3,11 @@ import { PLPVariant } from "utils/groqTypes/ProductList";
 import { Image } from "./Image";
 import { Price } from "./Price";
 
-export const Product = ({ item }: { item: PLPVariant }) => {
+type Props = {
+  item: PLPVariant;
+};
+
+export const Product = ({ item }: Props) => {
   const href = {
     pathname: `/products/${item.productSlug}`,
     query: {
@@ -14,7 +18,7 @@ export const Product = ({ item }: { item: PLPVariant }) => {
   return (
     <div className="flex flex-col gap-3 group">
       <Link href={href} className="group-hover:shadow-lg rounded-lg overflow-hidden transition-shadow duration-150">
-        <Image width={600} height={600} src={item.images} alt={item.imageAlt} layout="responsive" />
+        <Image width={600} height={600} src={item.images} alt={item.name} layout="responsive" />
       </Link>
       <Link href={href} className="text-primary">
         <h3 className="text-h6 mb-1">{item.name}</h3>

--- a/packages/nextjs/pages/products/[slug].tsx
+++ b/packages/nextjs/pages/products/[slug].tsx
@@ -65,18 +65,10 @@ const ProductPage: NextPage<PageProps> = ({ data }) => {
             return (
               <div key={prod._id} className="w-full">
                 <Product
-                  // TODO: make the interface for Product more generic so it can take result from GQL also
                   item={{
-                    _id: variant._id ?? "",
-                    slug: variant?.slug || "",
+                    ...variant,
                     productSlug: prod.slug || "",
-                    imageAlt: variant.name ?? "",
-                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                    // @ts-ignore
                     images: image,
-                    msrp: variant.msrp ?? 0,
-                    name: variant.name ?? "",
-                    price: variant.price ?? 0,
                   }}
                 />
               </div>

--- a/packages/nextjs/pages/products/index.tsx
+++ b/packages/nextjs/pages/products/index.tsx
@@ -4,7 +4,7 @@ import { AnimatePresence } from "framer-motion";
 import { useRouter } from "next/router";
 import classNames from "classnames";
 
-import { GetAllFilteredVariants, getFilteredPaginatedQuery } from "utils/getFilteredPaginatedQuery";
+import { getAllFilteredVariants } from "utils/getFilteredPaginatedQuery";
 import { getCategoryFilters, getFlavourFilters, getStyleFilters } from "utils/getFilters";
 import { getPaginationFromQuery } from "utils/getPaginationFromQuery";
 import { getFiltersFromQuery } from "utils/getFiltersFromQuery";
@@ -12,13 +12,7 @@ import { getOrderingFromQuery } from "utils/getOrderingFromQuery";
 import { setCachingHeaders } from "utils/setCachingHeaders";
 import { SanityType } from "utils/consts";
 import { pluralize } from "utils/pluralize";
-import {
-  CategoryFilterItem,
-  FlavourFilterItem,
-  PLPVariant,
-  PLPVariantList,
-  StyleFilterItem,
-} from "utils/groqTypes/ProductList";
+import { CategoryFilterItem, FlavourFilterItem, PLPVariant, StyleFilterItem } from "utils/groqTypes/ProductList";
 import { useDeviceSize } from "utils/useDeviceSize";
 
 import { PageHead } from "components/PageHead";
@@ -165,8 +159,7 @@ export const getServerSideProps = (async ({ query, res, resolvedUrl }) => {
   const filters = getFiltersFromQuery(query, { flavourFilters, styleFilters, categoryFilters });
   // Pagination data.
   const pagination = getPaginationFromQuery(query);
-
-  const result = await getFilteredPaginatedQuery<PLPVariantList>(GetAllFilteredVariants(filters, order), pagination);
+  const result = await getAllFilteredVariants(filters, order, pagination);
 
   const { variants, itemCount } = result;
   const { currentPage, pageSize } = pagination;

--- a/packages/nextjs/utils/getFilteredPaginatedQuery.ts
+++ b/packages/nextjs/utils/getFilteredPaginatedQuery.ts
@@ -1,27 +1,36 @@
-import groq from "groq";
-import { sanityClient } from "./sanityClient";
+import { q, sanityImage, TypeFromSelection } from "groqd";
+import { runQuery } from "./sanityClient";
+import { GetPaginationResponse } from "./getPaginationFromQuery";
 
-export function GetAllFilteredVariants(filters = "", order = "") {
-  return groq`
-  {
-    'variants': *[_type == "variant"]${filters} {
-      _id, name, msrp, price,
-      'slug': slug.current,
-      'imageAlt': name,
-      'images': images[0],
-      'productSlug': *[_type == "product"][references(^._id)][0].slug.current
-    } ${order} [$offsetPage...$limit],
-    'itemCount': count(*[_type == "variant"]${filters}),
-  }`;
-}
-
-export const getFilteredPaginatedQuery = async <T>(
-  query: string,
-  queryOptions: {
-    offsetPage: number;
-    limit: number;
-    [key: string]: any;
-  }
-): Promise<T> => {
-  return await sanityClient.fetch(query, queryOptions);
+const variantSelection = {
+  _id: q.string(),
+  name: q.string(),
+  msrp: q.number(),
+  price: q.number(),
+  slug: q.slug("slug"),
+  images: sanityImage("images").filter().slice(0),
+  productSlug: q("*")
+    .filterByType("product")
+    .filter("references(^._id)")
+    .slice(0)
+    .grabOne("slug.current", q.string().nullable()),
 };
+
+export const getAllFilteredVariants = (
+  filters = "",
+  order: `${string} ${"asc" | "desc"}`,
+  pagination: GetPaginationResponse
+) =>
+  runQuery(
+    q("").grab({
+      variants: q("*")
+        .filterByType("variant")
+        .filter(filters)
+        .grab(variantSelection)
+        .order(order)
+        .slice(pagination.offsetPage, pagination.limit - 1),
+      itemCount: [`count(*[_type == "variant"][${filters}])`, q.number()],
+    })
+  );
+
+export type FilteredPaginatedQuery = { itemCount: number; variants: TypeFromSelection<typeof variantSelection>[] };

--- a/packages/nextjs/utils/getFiltersFromQuery.ts
+++ b/packages/nextjs/utils/getFiltersFromQuery.ts
@@ -14,7 +14,7 @@ export const getFiltersFromQuery = (
         return acc;
       }
 
-      const queryValueIsString = typeof queryValue === "string" || queryValue instanceof String;
+      const queryValueIsString = typeof queryValue === "string" && !Array.isArray(queryValue);
       if (queryValueIsString) {
         const filterOption = options.find(({ value }) => value === queryValue);
         // Check query value validity
@@ -50,5 +50,5 @@ export const getFiltersFromQuery = (
    * Creates AND statement of filter groups
    * e.g. given (MD || XL) and (on sale), constructed filter would check for ((MD || XL) && (on sale))
    *  */
-  return constructedGroups.length ? `[${constructedGroups.join("][")}]` : "";
+  return constructedGroups.length ? `${constructedGroups.join("][")}` : "";
 };

--- a/packages/nextjs/utils/getOrderingFromQuery.ts
+++ b/packages/nextjs/utils/getOrderingFromQuery.ts
@@ -5,14 +5,14 @@ export const getOrderingFromQuery = (query: ParsedUrlQuery) => {
   const { [SORT_QUERY_PARAM]: sortValue } = query;
 
   // Sort/ordering
-  let ordering = "| order(_createdAt)";
+  let ordering = SORT_OPTIONS.default.ordering;
   if (sortValue) {
     // If sort is string[], use first item
     // (e.g. User modified url, wouldn't happen normally)
     const sortType = Array.isArray(sortValue) ? sortValue[0] : sortValue;
     const sortOption = SORT_OPTIONS[sortType];
     if (sortOption?.ordering) {
-      ordering = `| order(${sortOption.ordering})`;
+      ordering = sortOption.ordering;
     }
   }
 

--- a/packages/nextjs/utils/groqTypes/ProductList.ts
+++ b/packages/nextjs/utils/groqTypes/ProductList.ts
@@ -1,17 +1,9 @@
 import { TypeFromSelection } from "groqd";
 import { categorySelection, getAllCategories } from "../getAllCategoriesQuery";
 import { getAllProducts, productSelection } from "../getAllProductsQuery";
+import { FilteredPaginatedQuery } from "../getFilteredPaginatedQuery";
 
-export interface PLPVariant {
-  _id: string;
-  slug: string;
-  name: string;
-  msrp: number;
-  price: number;
-  images: Asset[];
-  imageAlt: string;
-  productSlug: string;
-}
+export type PLPVariant = FilteredPaginatedQuery["variants"][number];
 
 export interface PLPVariantList {
   variants: PLPVariant[];

--- a/packages/nextjs/utils/sorting.ts
+++ b/packages/nextjs/utils/sorting.ts
@@ -7,7 +7,7 @@ export type SortOption = {
   value: string;
   label: string;
   type: SortType;
-  ordering: string;
+  ordering: `${string} ${"asc" | "desc"}`;
 };
 
 export const SORT_QUERY_PARAM = "sort";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,7 +293,7 @@ packages:
       '@babel/traverse': 7.20.13
       '@babel/types': 7.20.7
       convert-source-map: 1.8.0
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.0
@@ -1806,7 +1806,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/parser': 7.20.13
       '@babel/types': 7.20.7
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -2229,7 +2229,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       espree: 9.4.0
       globals: 13.17.0
       ignore: 5.2.0
@@ -2305,7 +2305,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -2731,7 +2731,7 @@ packages:
       '@open-draft/until': 1.0.3
       '@types/debug': 4.1.7
       '@xmldom/xmldom': 0.7.5
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       headers-polyfill: 3.1.0
       outvariant: 1.3.0
       strict-event-emitter: 0.2.6
@@ -3870,7 +3870,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.36.1
       '@typescript-eslint/types': 5.36.1
       '@typescript-eslint/typescript-estree': 5.36.1(typescript@4.9.4)
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       eslint: 8.23.0
       typescript: 4.9.4
     transitivePeerDependencies:
@@ -3992,7 +3992,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.36.1
       '@typescript-eslint/visitor-keys': 5.36.1
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
@@ -4243,7 +4243,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -5341,6 +5341,17 @@ packages:
     dependencies:
       ms: 2.0.0
 
+  /debug@3.2.7:
+    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
+    dev: true
+
   /debug@3.2.7(supports-color@8.1.1):
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
@@ -5351,6 +5362,17 @@ packages:
     dependencies:
       ms: 2.1.3
       supports-color: 8.1.1
+
+  /debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
 
   /debug@4.3.4(supports-color@5.5.0):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -5795,7 +5817,7 @@ packages:
   /eslint-import-resolver-node@0.3.6:
     resolution: {integrity: sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==}
     dependencies:
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7
       resolve: 1.22.1
     transitivePeerDependencies:
       - supports-color
@@ -5808,7 +5830,7 @@ packages:
       eslint: '*'
       eslint-plugin-import: '*'
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       eslint: 8.23.0
       eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.36.1)(eslint-import-resolver-typescript@2.7.1)(eslint@8.23.0)
       glob: 7.2.3
@@ -5841,7 +5863,7 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/parser': 5.36.1(eslint@8.23.0)(typescript@4.9.4)
-      debug: 3.2.7(supports-color@8.1.1)
+      debug: 3.2.7
       eslint: 8.23.0
       eslint-import-resolver-node: 0.3.6
       eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.26.0)(eslint@8.23.0)
@@ -6026,7 +6048,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.1.1
@@ -7015,7 +7037,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -7033,7 +7055,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
 
@@ -7510,7 +7532,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.4(supports-color@8.1.1)
+      debug: 4.3.4
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:


### PR DESCRIPTION
Converts the Product filtering and sorting to use Groqd.

To test → https://nextjs-sanity-m3adfm7h1-formidable-labs.vercel.app/products

Select and deselect filters and sorting to verify the results look accurate.