### PR TITLE
chore pnpm v8

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: pnpm/action-setup@v2.2.2
         with:
-          version: 7
+          version: 8
 
       - name: "Get pnpm store directory"
         id: pnpm-cache
@@ -57,7 +57,7 @@ jobs:
 
       - uses: pnpm/action-setup@v2.2.2
         with:
-          version: 7
+          version: 8
 
       - name: "Get pnpm store directory"
         id: pnpm-cache
@@ -98,4 +98,3 @@ jobs:
       - name: "Storybook: Run Tests"
         working-directory: packages/nextjs
         run: pnpm run test:storybook:start
-

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: pnpm/action-setup@v2.2.2
         with:
-          version: 7
+          version: 8
 
       - name: Get pnpm store directory
         id: pnpm-cache
@@ -54,6 +54,5 @@ jobs:
 
       - name: Cypress Run (Production Backend)
         run: pnpm run test:e2e-real:start
-
 #      - name: Cypress Run (Mock Backend)
 #        run: pnpm run test:e2e-mock:start

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 public-hoist-pattern[]=*@sanity/*
+auto-install-peers=false

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
 public-hoist-pattern[]=*@sanity/*
-auto-install-peers=false
+auto-install-peers=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
 public-hoist-pattern[]=*@sanity/*
-auto-install-peers=true
+auto-install-peers=false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 importers:
 
   .:
@@ -117,7 +121,7 @@ importers:
         version: 13.4.0(@babel/core@7.22.15)(react-dom@18.2.0)(react@18.2.0)
       next-sanity:
         specifier: ^4.2.0
-        version: 4.2.0(@sanity/icons@2.3.1)(@sanity/types@3.9.1)(@sanity/ui@1.3.2)(@types/styled-components@5.1.26)(next@13.4.0)(react@18.2.0)(sanity@3.9.1)(styled-components@5.3.10)
+        version: 4.2.0(@sanity/icons@2.3.1)(@sanity/types@3.9.1)(@sanity/ui@1.3.2)(@types/styled-components@5.1.29)(next@13.4.0)(react@18.2.0)(sanity@3.9.1)(styled-components@5.3.10)
       node-fetch:
         specifier: ^3.2.10
         version: 3.2.10
@@ -1741,6 +1745,23 @@ packages:
       '@babel/parser': 7.22.16
       '@babel/types': 7.22.15
 
+  /@babel/traverse@7.20.13:
+    resolution: {integrity: sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.22.13
+      '@babel/generator': 7.22.15
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-hoist-variables': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/parser': 7.22.16
+      '@babel/types': 7.22.15
+      debug: 4.3.4(supports-color@8.1.1)
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+
   /@babel/traverse@7.20.13(supports-color@5.5.0):
     resolution: {integrity: sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==}
     engines: {node: '>=6.9.0'}
@@ -1757,6 +1778,7 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@babel/traverse@7.22.15:
     resolution: {integrity: sha512-DdHPwvJY0sEeN4xJU5uRLmZjgMMDIvMPniLuYzUVXj/GGzysPl0/fwt44JBkyUIzGJPV8QgHMcQdQ34XFuKTYQ==}
@@ -1990,6 +2012,7 @@ packages:
 
   /@emotion/memoize@0.7.4:
     resolution: {integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==}
+    requiresBuild: true
     dev: false
     optional: true
 
@@ -3953,7 +3976,7 @@ packages:
     engines: {node: '>=14.18.0'}
     hasBin: true
     dependencies:
-      '@babel/traverse': 7.20.13(supports-color@5.5.0)
+      '@babel/traverse': 7.20.13
       '@vercel/frameworks': 1.3.4
       '@vercel/fs-detectors': 3.8.9
       chalk: 4.1.2
@@ -4259,7 +4282,7 @@ packages:
     resolution: {integrity: sha512-A6M86wIAuM2EYzTxUpPkZmZug0PJDmbZK5a7E5VfkWzJFKRvHNa3ZmVGXijHE7M/1KOJH+t1KQeqLkfMsYq4Ig==}
     dependencies:
       '@sanity/client': 5.4.2
-      '@types/react': 18.0.27
+      '@types/react': 18.2.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -5172,7 +5195,7 @@ packages:
       memoizerific: 1.11.3
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      semver: 7.3.8
+      semver: 7.5.4
       store2: 2.14.2
       telejson: 7.2.0
       ts-dedent: 2.2.0
@@ -5519,7 +5542,7 @@ packages:
       '@storybook/channels': 7.4.0
       '@types/babel__core': 7.20.0
       '@types/express': 4.17.17
-      '@types/react': 16.14.46
+      '@types/react': 16.14.50
       file-system-cache: 2.3.0
     dev: true
 
@@ -6157,8 +6180,8 @@ packages:
       '@types/react': 18.0.18
     dev: false
 
-  /@types/react@16.14.46:
-    resolution: {integrity: sha512-Am4pyXMrr6cWWw/TN3oqHtEZl0j+G6Up/O8m65+xF/3ZaUgkv1GAtTPWw4yNRmH0HJXmur6xKCKoMo3rBGynuw==}
+  /@types/react@16.14.50:
+    resolution: {integrity: sha512-7TWZ/HjhXsRK3BbhSFxTinbSft3sUXJAU3ONngT0rpcKJaIOlxkRke4bidqQTopUbEv1ApC5nlSEkIpX43MkTg==}
     dependencies:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2
@@ -6170,10 +6193,10 @@ packages:
     dependencies:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2
-      csstype: 3.1.0
+      csstype: 3.1.1
 
-  /@types/react@18.0.27:
-    resolution: {integrity: sha512-3vtRKHgVxu3Jp9t718R9BuzoD4NcQ8YJ5XRzsSKxNDiDonD2MXIT1TmSkenxuCycZJoQT5d2vE8LwWJxBC1gmA==}
+  /@types/react@18.2.0:
+    resolution: {integrity: sha512-0FLj93y5USLHdnhIhABk83rm8XEGA7kH3cr+YUlvxoUGp1xNt/DINUMvqPxLyOQMzLmZe8i4RTHbvb8MC7NmrA==}
     dependencies:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2
@@ -6228,8 +6251,8 @@ packages:
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
     dev: true
 
-  /@types/styled-components@5.1.26:
-    resolution: {integrity: sha512-KuKJ9Z6xb93uJiIyxo/+ksS7yLjS1KzG6iv5i78dhVg/X3u5t1H7juRWqVmodIdz6wGVaIApo1u01kmFRdJHVw==}
+  /@types/styled-components@5.1.29:
+    resolution: {integrity: sha512-5h/ah9PAblggQ6Laa4peplT4iY5ddA8qM1LMD4HzwToUWs3hftfy0fayeRgbtH1JZUdw5CCaowmz7Lnb8SjIxQ==}
     dependencies:
       '@types/hoist-non-react-statics': 3.3.1
       '@types/react': 18.0.18
@@ -6779,12 +6802,12 @@ packages:
       acorn: 7.4.1
       acorn-walk: 7.2.0
 
-  /acorn-import-assertions@1.9.0(acorn@8.8.1):
+  /acorn-import-assertions@1.9.0(acorn@8.10.0):
     resolution: {integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==}
     peerDependencies:
       acorn: ^8
     dependencies:
-      acorn: 8.8.1
+      acorn: 8.10.0
     dev: true
 
   /acorn-jsx@5.3.2(acorn@7.4.1):
@@ -8536,6 +8559,7 @@ packages:
   /cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
+    hasBin: true
 
   /cssom@0.3.8:
     resolution: {integrity: sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==}
@@ -8548,9 +8572,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       cssom: 0.3.8
-
-  /csstype@3.1.0:
-    resolution: {integrity: sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==}
 
   /csstype@3.1.1:
     resolution: {integrity: sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==}
@@ -8705,6 +8726,7 @@ packages:
     dependencies:
       ms: 2.1.2
       supports-color: 5.5.0
+    dev: false
 
   /debug@4.3.4(supports-color@8.1.1):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -8906,6 +8928,7 @@ packages:
   /detective@5.2.1:
     resolution: {integrity: sha512-v9XE1zRnz1wRtgurGu0Bs8uHKFSTdteYZNbIPFVhUZ39L/S79ppMpdmVOZAnoz1jfEFodc48n6MX483Xo3t1yw==}
     engines: {node: '>=0.8.0'}
+    hasBin: true
     dependencies:
       acorn-node: 1.8.2
       defined: 1.0.0
@@ -9508,7 +9531,7 @@ packages:
       eslint: 8.23.0
       eslint-import-resolver-node: 0.3.6
       eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.26.0)(eslint@8.23.0)
-      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.36.1)(eslint-import-resolver-typescript@2.7.1)(eslint@8.23.0)
+      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.48.1)(eslint@8.23.0)
       eslint-plugin-jsx-a11y: 6.6.1(eslint@8.23.0)
       eslint-plugin-react: 7.31.1(eslint@8.23.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.23.0)
@@ -9545,7 +9568,7 @@ packages:
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.23.0
-      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.36.1)(eslint-import-resolver-typescript@2.7.1)(eslint@8.23.0)
+      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.48.1)(eslint@8.23.0)
       glob: 7.2.3
       is-glob: 4.0.3
       resolve: 1.22.6
@@ -9554,7 +9577,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils@2.7.4(@typescript-eslint/parser@5.36.1)(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@2.7.1)(eslint@8.23.0):
+  /eslint-module-utils@2.7.4(@typescript-eslint/parser@5.48.1)(eslint-import-resolver-node@0.3.6)(eslint@8.23.0):
     resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -9575,16 +9598,15 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.36.1(eslint@8.23.0)(typescript@4.9.4)
+      '@typescript-eslint/parser': 5.48.1(eslint@8.31.0)(typescript@4.9.4)
       debug: 3.2.7(supports-color@8.1.1)
       eslint: 8.23.0
       eslint-import-resolver-node: 0.3.6
-      eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.26.0)(eslint@8.23.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.36.1)(eslint-import-resolver-typescript@2.7.1)(eslint@8.23.0):
+  /eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.48.1)(eslint@8.23.0):
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -9594,14 +9616,14 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.36.1(eslint@8.23.0)(typescript@4.9.4)
+      '@typescript-eslint/parser': 5.48.1(eslint@8.31.0)(typescript@4.9.4)
       array-includes: 3.1.5
       array.prototype.flat: 1.3.0
       debug: 2.6.9
       doctrine: 2.1.0
       eslint: 8.23.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.36.1)(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@2.7.1)(eslint@8.23.0)
+      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.48.1)(eslint-import-resolver-node@0.3.6)(eslint@8.23.0)
       has: 1.0.3
       is-core-module: 2.10.0
       is-glob: 4.0.3
@@ -10168,16 +10190,6 @@ packages:
   /fast-diff@1.2.0:
     resolution: {integrity: sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==}
     dev: true
-
-  /fast-glob@3.2.11:
-    resolution: {integrity: sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==}
-    engines: {node: '>=8.6.0'}
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
-      glob-parent: 5.1.2
-      merge2: 1.4.1
-      micromatch: 4.0.5
 
   /fast-glob@3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
@@ -11032,8 +11044,8 @@ packages:
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.2.11
-      ignore: 5.2.0
+      fast-glob: 3.3.1
+      ignore: 5.2.4
       merge2: 1.4.1
       slash: 3.0.0
     dev: true
@@ -11729,6 +11741,7 @@ packages:
     resolution: {integrity: sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==}
     dependencies:
       has: 1.0.3
+    dev: true
 
   /is-core-module@2.13.0:
     resolution: {integrity: sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==}
@@ -13996,7 +14009,7 @@ packages:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
     dev: true
 
-  /next-sanity@4.2.0(@sanity/icons@2.3.1)(@sanity/types@3.9.1)(@sanity/ui@1.3.2)(@types/styled-components@5.1.26)(next@13.4.0)(react@18.2.0)(sanity@3.9.1)(styled-components@5.3.10):
+  /next-sanity@4.2.0(@sanity/icons@2.3.1)(@sanity/types@3.9.1)(@sanity/ui@1.3.2)(@types/styled-components@5.1.29)(next@13.4.0)(react@18.2.0)(sanity@3.9.1)(styled-components@5.3.10):
     resolution: {integrity: sha512-4GNEgXXDWPlvXqdJaAfKBR8BNvwQqUCynJ9GCgL6tVGcfZvcAImyZkzLTXj75PTZDPDcc7OfKHXg+XbmbUp7hA==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -14015,7 +14028,7 @@ packages:
       '@sanity/types': 3.9.1
       '@sanity/ui': 1.3.2(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.10)
       '@sanity/webhook': 2.0.0
-      '@types/styled-components': 5.1.26
+      '@types/styled-components': 5.1.29
       groq: 3.9.1
       next: 13.4.0(@babel/core@7.22.15)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
@@ -15900,14 +15913,6 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /resolve@1.22.1:
-    resolution: {integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==}
-    hasBin: true
-    dependencies:
-      is-core-module: 2.10.0
-      path-parse: 1.0.7
-      supports-preserve-symlinks-flag: 1.0.0
-
   /resolve@1.22.6:
     resolution: {integrity: sha512-njhxM7mV12JfufShqGy3Rz8j11RPdLy4xi15UurGJeoHLfJpVXKdh3ueuOqbYUcDZnffr6X739JBo5LzyahEsw==}
     hasBin: true
@@ -17028,7 +17033,7 @@ packages:
       detective: 5.2.1
       didyoumean: 1.2.2
       dlv: 1.1.3
-      fast-glob: 3.2.11
+      fast-glob: 3.3.1
       glob-parent: 6.0.2
       is-glob: 4.0.3
       lilconfig: 2.0.6
@@ -17043,7 +17048,7 @@ packages:
       postcss-selector-parser: 6.0.10
       postcss-value-parser: 4.2.0
       quick-lru: 5.1.1
-      resolve: 1.22.1
+      resolve: 1.22.6
     transitivePeerDependencies:
       - ts-node
 
@@ -17289,6 +17294,7 @@ packages:
 
   /tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
     dev: true
 
   /ts-dedent@2.2.0:
@@ -17944,8 +17950,8 @@ packages:
       '@webassemblyjs/ast': 1.11.6
       '@webassemblyjs/wasm-edit': 1.11.6
       '@webassemblyjs/wasm-parser': 1.11.6
-      acorn: 8.8.1
-      acorn-import-assertions: 1.9.0(acorn@8.8.1)
+      acorn: 8.10.0
+      acorn-import-assertions: 1.9.0(acorn@8.10.0)
       browserslist: 4.21.10
       chrome-trace-event: 1.0.3
       enhanced-resolve: 5.15.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: '6.0'
 
 settings:
-  autoInstallPeers: true
+  autoInstallPeers: false
   excludeLinksFromLockfile: false
 
 importers:
@@ -31,7 +31,7 @@ importers:
         version: 8.0.3
       inquirer-autocomplete-prompt:
         specifier: ^3.0.0
-        version: 3.0.0(inquirer@9.2.11)
+        version: 3.0.0
       lint-staged:
         specifier: ^13.1.0
         version: 13.1.0
@@ -73,7 +73,7 @@ importers:
         version: 1.3.2(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.10)
       '@sanity/vision':
         specifier: ^3.9.1
-        version: 3.9.1(@babel/runtime@7.22.15)(@codemirror/lint@6.1.0)(@codemirror/state@6.2.0)(@codemirror/theme-one-dark@6.1.0)(@lezer/common@1.0.2)(codemirror@6.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.10)
+        version: 3.9.1(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.10)
       '@sanity/webhook':
         specifier: ^2.0.0
         version: 2.0.0
@@ -109,7 +109,7 @@ importers:
         version: 0.15.4
       groqd-playground:
         specifier: ^0.0.12
-        version: 0.0.12(@sanity/icons@2.3.1)(@sanity/ui@1.3.2)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(sanity@3.9.1)(styled-components@5.3.10)
+        version: 0.0.12(@sanity/ui@1.3.2)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(sanity@3.9.1)(styled-components@5.3.10)
       jsdom:
         specifier: ^20.0.0
         version: 20.0.0
@@ -118,10 +118,10 @@ importers:
         version: 4.0.8
       next:
         specifier: ^13.4.0
-        version: 13.4.0(@babel/core@7.22.15)(react-dom@18.2.0)(react@18.2.0)
+        version: 13.4.0(react-dom@18.2.0)(react@18.2.0)
       next-sanity:
         specifier: ^4.2.0
-        version: 4.2.0(@sanity/icons@2.3.1)(@sanity/types@3.9.1)(@sanity/ui@1.3.2)(@types/styled-components@5.1.29)(next@13.4.0)(react@18.2.0)(sanity@3.9.1)(styled-components@5.3.10)
+        version: 4.2.0(@sanity/ui@1.3.2)(next@13.4.0)(react@18.2.0)(sanity@3.9.1)(styled-components@5.3.10)
       node-fetch:
         specifier: ^3.2.10
         version: 3.2.10
@@ -173,7 +173,7 @@ importers:
         version: 0.2.2(jest@29.3.1)
       '@storybook/nextjs':
         specifier: ^7.4.0
-        version: 7.4.0(@swc/core@1.3.83)(@types/react-dom@18.0.6)(@types/react@18.0.18)(esbuild@0.16.17)(next@13.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.4)(webpack@5.88.2)
+        version: 7.4.0(@types/react-dom@18.0.6)(@types/react@18.0.18)(next@13.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.4)
       '@storybook/react':
         specifier: ^7.4.0
         version: 7.4.0(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.4)
@@ -1813,13 +1813,8 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
-  /@codemirror/autocomplete@6.4.0(@codemirror/language@6.4.0)(@codemirror/state@6.2.0)(@codemirror/view@6.7.3)(@lezer/common@1.0.2):
+  /@codemirror/autocomplete@6.4.0:
     resolution: {integrity: sha512-HLF2PnZAm1s4kGs30EiqKMgD7XsYaQ0XJnMR0rofEWQ5t5D60SfqpDIkIh1ze5tiEbyUWm8+VJ6W1/erVvBMIA==}
-    peerDependencies:
-      '@codemirror/language': ^6.0.0
-      '@codemirror/state': ^6.0.0
-      '@codemirror/view': ^6.0.0
-      '@lezer/common': ^1.0.0
     dependencies:
       '@codemirror/language': 6.4.0
       '@codemirror/state': 6.2.0
@@ -1839,7 +1834,7 @@ packages:
   /@codemirror/lang-javascript@6.1.2:
     resolution: {integrity: sha512-OcwLfZXdQ1OHrLiIcKCn7MqZ7nx205CMKlhe+vL88pe2ymhT9+2P+QhwkYGxMICj8TDHyp8HFKVwpiisUT7iEQ==}
     dependencies:
-      '@codemirror/autocomplete': 6.4.0(@codemirror/language@6.4.0)(@codemirror/state@6.2.0)(@codemirror/view@6.7.3)(@lezer/common@1.0.2)
+      '@codemirror/autocomplete': 6.4.0
       '@codemirror/language': 6.4.0
       '@codemirror/lint': 6.1.0
       '@codemirror/state': 6.2.0
@@ -3335,7 +3330,7 @@ packages:
       react-refresh: 0.11.0
       schema-utils: 3.3.0
       source-map: 0.7.4
-      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
+      webpack: 5.88.2
     dev: true
 
   /@portabletext/react@1.0.6(react@18.2.0):
@@ -4337,13 +4332,13 @@ packages:
       - supports-color
     dev: false
 
-  /@sanity/vision@3.9.1(@babel/runtime@7.22.15)(@codemirror/lint@6.1.0)(@codemirror/state@6.2.0)(@codemirror/theme-one-dark@6.1.0)(@lezer/common@1.0.2)(codemirror@6.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.10):
+  /@sanity/vision@3.9.1(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.10):
     resolution: {integrity: sha512-pRcaierrdo6rqL+59UBuNnMfATX5iobvaijFS/okqjdgloZHfhstph0W4GUp79cqxjZFi9qQffa2lguU3pWcjA==}
     peerDependencies:
       react: ^18
       styled-components: ^5.2
     dependencies:
-      '@codemirror/autocomplete': 6.4.0(@codemirror/language@6.4.0)(@codemirror/state@6.2.0)(@codemirror/view@6.7.3)(@lezer/common@1.0.2)
+      '@codemirror/autocomplete': 6.4.0
       '@codemirror/commands': 6.2.0
       '@codemirror/lang-javascript': 6.1.2
       '@codemirror/language': 6.4.0
@@ -4356,7 +4351,7 @@ packages:
       '@sanity/color': 2.2.2
       '@sanity/icons': 2.3.1(react@18.2.0)
       '@sanity/ui': 1.3.2(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.10)
-      '@uiw/react-codemirror': 4.19.7(@babel/runtime@7.22.15)(@codemirror/autocomplete@6.4.0)(@codemirror/language@6.4.0)(@codemirror/lint@6.1.0)(@codemirror/search@6.2.3)(@codemirror/state@6.2.0)(@codemirror/theme-one-dark@6.1.0)(@codemirror/view@6.7.3)(codemirror@6.0.1)(react-dom@18.2.0)(react@18.2.0)
+      '@uiw/react-codemirror': 4.19.7(@codemirror/autocomplete@6.4.0)(@codemirror/language@6.4.0)(@codemirror/search@6.2.3)(@codemirror/view@6.7.3)(react-dom@18.2.0)(react@18.2.0)
       hashlru: 2.3.0
       is-hotkey: 0.1.8
       json5: 2.2.3
@@ -4364,12 +4359,6 @@ packages:
       react: 18.2.0
       styled-components: 5.3.10(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
     transitivePeerDependencies:
-      - '@babel/runtime'
-      - '@codemirror/lint'
-      - '@codemirror/state'
-      - '@codemirror/theme-one-dark'
-      - '@lezer/common'
-      - codemirror
       - react-dom
       - react-is
     dev: false
@@ -4814,7 +4803,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/builder-webpack5@7.4.0(esbuild@0.16.17)(typescript@4.9.4):
+  /@storybook/builder-webpack5@7.4.0(typescript@4.9.4):
     resolution: {integrity: sha512-CYeXppqGACzDUpLCFvWvwD7IjN7VNi7+nwQ1uRNgW2NgBMOIldZe+gcTXcc0BuHyIitU5/vvquYM0qjis05LYw==}
     peerDependencies:
       typescript: '*'
@@ -4849,13 +4838,13 @@ packages:
       semver: 7.3.8
       style-loader: 3.3.3(webpack@5.88.2)
       swc-loader: 0.2.3(@swc/core@1.3.83)(webpack@5.88.2)
-      terser-webpack-plugin: 5.3.9(@swc/core@1.3.83)(esbuild@0.16.17)(webpack@5.88.2)
+      terser-webpack-plugin: 5.3.9(@swc/core@1.3.83)(webpack@5.88.2)
       ts-dedent: 2.2.0
       typescript: 4.9.4
       url: 0.11.1
       util: 0.12.4
       util-deprecate: 1.0.2
-      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
+      webpack: 5.88.2(@swc/core@1.3.83)
       webpack-dev-middleware: 6.1.1(webpack@5.88.2)
       webpack-hot-middleware: 2.25.4
       webpack-virtual-modules: 0.5.0
@@ -5209,7 +5198,7 @@ packages:
     resolution: {integrity: sha512-TXJJd5RAKakWx4BtpwvSNdgTDkKM6RkXU8GK34S/LhidQ5Pjz3wcnqb0TxEkfhK/ztbP8nKHqXFwLfa2CYkvQw==}
     dev: true
 
-  /@storybook/nextjs@7.4.0(@swc/core@1.3.83)(@types/react-dom@18.0.6)(@types/react@18.0.18)(esbuild@0.16.17)(next@13.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.4)(webpack@5.88.2):
+  /@storybook/nextjs@7.4.0(@types/react-dom@18.0.6)(@types/react@18.0.18)(next@13.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.4):
     resolution: {integrity: sha512-nGmer4Hu1/XX3+XyxfAkQ9d16Qsj467aLc7MTNQ2uFyYAksCqT3bvznooUOcD/X5NfoyL2YA78OczGdt1HFFpQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -5243,10 +5232,10 @@ packages:
       '@babel/preset-typescript': 7.22.15(@babel/core@7.22.15)
       '@babel/runtime': 7.22.15
       '@storybook/addon-actions': 7.4.0(@types/react-dom@18.0.6)(@types/react@18.0.18)(react-dom@18.2.0)(react@18.2.0)
-      '@storybook/builder-webpack5': 7.4.0(esbuild@0.16.17)(typescript@4.9.4)
+      '@storybook/builder-webpack5': 7.4.0(typescript@4.9.4)
       '@storybook/core-common': 7.4.0
       '@storybook/node-logger': 7.4.0
-      '@storybook/preset-react-webpack': 7.4.0(@babel/core@7.22.15)(@swc/core@1.3.83)(esbuild@0.16.17)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.4)
+      '@storybook/preset-react-webpack': 7.4.0(@babel/core@7.22.15)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.4)
       '@storybook/preview-api': 7.4.0
       '@storybook/react': 7.4.0(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.4)
       '@types/node': 16.18.48
@@ -5255,15 +5244,15 @@ packages:
       fs-extra: 11.1.1
       image-size: 1.0.2
       loader-utils: 3.2.1
-      next: 13.4.0(@babel/core@7.22.15)(react-dom@18.2.0)(react@18.2.0)
-      node-polyfill-webpack-plugin: 2.0.1(webpack@5.88.2)
+      next: 13.4.0(react-dom@18.2.0)(react@18.2.0)
+      node-polyfill-webpack-plugin: 2.0.1
       pnp-webpack-plugin: 1.7.0(typescript@4.9.4)
       postcss: 8.4.21
-      postcss-loader: 7.3.3(postcss@8.4.21)(typescript@4.9.4)(webpack@5.88.2)
+      postcss-loader: 7.3.3(postcss@8.4.21)(typescript@4.9.4)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       resolve-url-loader: 5.0.0
-      sass-loader: 12.6.0(webpack@5.88.2)
+      sass-loader: 12.6.0
       semver: 7.3.8
       style-loader: 3.3.3(webpack@5.88.2)
       styled-jsx: 5.1.1(@babel/core@7.22.15)(react@18.2.0)
@@ -5271,7 +5260,6 @@ packages:
       tsconfig-paths: 4.2.0
       tsconfig-paths-webpack-plugin: 4.1.0
       typescript: 4.9.4
-      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/helpers'
@@ -5303,7 +5291,7 @@ packages:
     resolution: {integrity: sha512-ZVBZggqkuj7ysfuHSCd/J7ovWV06zY9uWf+VU+Zw7ZeojDT8QHFrCurPsN7D9679j9vRU1/kSzqvAiStALS33g==}
     dev: true
 
-  /@storybook/preset-react-webpack@7.4.0(@babel/core@7.22.15)(@swc/core@1.3.83)(esbuild@0.16.17)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.4):
+  /@storybook/preset-react-webpack@7.4.0(@babel/core@7.22.15)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.4):
     resolution: {integrity: sha512-9iZ9lvhRUYtxXmJMqR7txNyatrHryqo6FSKzfpUzmcCySn3d7mu9I6LEPxEir43TkPnBio3W4EsbvtIhjJ5ekA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -5336,7 +5324,7 @@ packages:
       react-refresh: 0.11.0
       semver: 7.3.8
       typescript: 4.9.4
-      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
+      webpack: 5.88.2
     transitivePeerDependencies:
       - '@swc/core'
       - '@types/webpack'
@@ -5389,7 +5377,7 @@ packages:
       react-docgen-typescript: 2.2.2(typescript@4.9.4)
       tslib: 2.4.1
       typescript: 4.9.4
-      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
+      webpack: 5.88.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5998,13 +5986,6 @@ packages:
       '@types/unist': 2.0.6
     dev: false
 
-  /@types/hoist-non-react-statics@3.3.1:
-    resolution: {integrity: sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==}
-    dependencies:
-      '@types/react': 18.0.18
-      hoist-non-react-statics: 3.3.2
-    dev: false
-
   /@types/html-minifier-terser@6.1.0:
     resolution: {integrity: sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==}
     dev: true
@@ -6250,14 +6231,6 @@ packages:
   /@types/stack-utils@2.0.1:
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
     dev: true
-
-  /@types/styled-components@5.1.29:
-    resolution: {integrity: sha512-5h/ah9PAblggQ6Laa4peplT4iY5ddA8qM1LMD4HzwToUWs3hftfy0fayeRgbtH1JZUdw5CCaowmz7Lnb8SjIxQ==}
-    dependencies:
-      '@types/hoist-non-react-statics': 3.3.1
-      '@types/react': 18.0.18
-      csstype: 3.1.1
-    dev: false
 
   /@types/testing-library__jest-dom@5.14.5:
     resolution: {integrity: sha512-SBwbxYoyPIvxHbeHxTZX2Pe/74F/tX2/D3mMvzabdeJ25bBojfW0TyB8BHrbq/9zaaKICJZjLP+8r6AeZMFCuQ==}
@@ -6526,18 +6499,16 @@ packages:
       eslint-visitor-keys: 3.3.0
     dev: true
 
-  /@uiw/codemirror-extensions-basic-setup@4.19.7(@codemirror/autocomplete@6.4.0)(@codemirror/commands@6.2.0)(@codemirror/language@6.4.0)(@codemirror/lint@6.1.0)(@codemirror/search@6.2.3)(@codemirror/state@6.2.0)(@codemirror/view@6.7.3):
+  /@uiw/codemirror-extensions-basic-setup@4.19.7(@codemirror/autocomplete@6.4.0)(@codemirror/commands@6.2.0)(@codemirror/language@6.4.0)(@codemirror/search@6.2.3)(@codemirror/view@6.7.3):
     resolution: {integrity: sha512-pk0JTFJAZOGxouBB1pdBtb59qKibO9DW4hER4VSFGBGW3TBDeXUwL/gKujhRpySHG2MtG09cgt4a3XOFIWwXTw==}
     peerDependencies:
       '@codemirror/autocomplete': '>=6.0.0'
       '@codemirror/commands': '>=6.0.0'
       '@codemirror/language': '>=6.0.0'
-      '@codemirror/lint': '>=6.0.0'
       '@codemirror/search': '>=6.0.0'
-      '@codemirror/state': '>=6.0.0'
       '@codemirror/view': '>=6.0.0'
     dependencies:
-      '@codemirror/autocomplete': 6.4.0(@codemirror/language@6.4.0)(@codemirror/state@6.2.0)(@codemirror/view@6.7.3)(@lezer/common@1.0.2)
+      '@codemirror/autocomplete': 6.4.0
       '@codemirror/commands': 6.2.0
       '@codemirror/language': 6.4.0
       '@codemirror/lint': 6.1.0
@@ -6546,14 +6517,10 @@ packages:
       '@codemirror/view': 6.7.3
     dev: false
 
-  /@uiw/react-codemirror@4.19.7(@babel/runtime@7.22.15)(@codemirror/autocomplete@6.4.0)(@codemirror/language@6.4.0)(@codemirror/lint@6.1.0)(@codemirror/search@6.2.3)(@codemirror/state@6.2.0)(@codemirror/theme-one-dark@6.1.0)(@codemirror/view@6.7.3)(codemirror@6.0.1)(react-dom@18.2.0)(react@18.2.0):
+  /@uiw/react-codemirror@4.19.7(@codemirror/autocomplete@6.4.0)(@codemirror/language@6.4.0)(@codemirror/search@6.2.3)(@codemirror/view@6.7.3)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-IHvpYWVSdiaHX0Fk6oY6YyAJigDnyvSpWKNUTRzsMNxB+8/wqZ8lior4TprXH0zyLxW5F1+bTyifFFTeg+X3Sw==}
     peerDependencies:
-      '@babel/runtime': '>=7.11.0'
-      '@codemirror/state': '>=6.0.0'
-      '@codemirror/theme-one-dark': '>=6.0.0'
       '@codemirror/view': '>=6.0.0'
-      codemirror: '>=6.0.0'
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
     dependencies:
@@ -6562,14 +6529,13 @@ packages:
       '@codemirror/state': 6.2.0
       '@codemirror/theme-one-dark': 6.1.0
       '@codemirror/view': 6.7.3
-      '@uiw/codemirror-extensions-basic-setup': 4.19.7(@codemirror/autocomplete@6.4.0)(@codemirror/commands@6.2.0)(@codemirror/language@6.4.0)(@codemirror/lint@6.1.0)(@codemirror/search@6.2.3)(@codemirror/state@6.2.0)(@codemirror/view@6.7.3)
-      codemirror: 6.0.1(@lezer/common@1.0.2)
+      '@uiw/codemirror-extensions-basic-setup': 4.19.7(@codemirror/autocomplete@6.4.0)(@codemirror/commands@6.2.0)(@codemirror/language@6.4.0)(@codemirror/search@6.2.3)(@codemirror/view@6.7.3)
+      codemirror: 6.0.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - '@codemirror/autocomplete'
       - '@codemirror/language'
-      - '@codemirror/lint'
       - '@codemirror/search'
     dev: false
 
@@ -6895,10 +6861,8 @@ packages:
       indent-string: 5.0.0
     dev: true
 
-  /ajv-formats@2.1.1(ajv@8.12.0):
+  /ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependencies:
-      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -7350,7 +7314,7 @@ packages:
       '@babel/core': 7.22.15
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
+      webpack: 5.88.2(@swc/core@1.3.83)
     dev: true
 
   /babel-plugin-add-react-displayname@0.0.5:
@@ -8110,18 +8074,16 @@ packages:
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
     dev: true
 
-  /codemirror@6.0.1(@lezer/common@1.0.2):
+  /codemirror@6.0.1:
     resolution: {integrity: sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==}
     dependencies:
-      '@codemirror/autocomplete': 6.4.0(@codemirror/language@6.4.0)(@codemirror/state@6.2.0)(@codemirror/view@6.7.3)(@lezer/common@1.0.2)
+      '@codemirror/autocomplete': 6.4.0
       '@codemirror/commands': 6.2.0
       '@codemirror/language': 6.4.0
       '@codemirror/lint': 6.1.0
       '@codemirror/search': 6.2.3
       '@codemirror/state': 6.2.0
       '@codemirror/view': 6.7.3
-    transitivePeerDependencies:
-      - '@lezer/common'
     dev: false
 
   /collect-v8-coverage@1.0.1:
@@ -8526,7 +8488,7 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.4.21)
       postcss-value-parser: 4.2.0
       semver: 7.3.8
-      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
+      webpack: 5.88.2(@swc/core@1.3.83)
     dev: true
 
   /css-select@4.3.0:
@@ -9531,7 +9493,7 @@ packages:
       eslint: 8.23.0
       eslint-import-resolver-node: 0.3.6
       eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.26.0)(eslint@8.23.0)
-      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.48.1)(eslint@8.23.0)
+      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.36.1)(eslint-import-resolver-typescript@2.7.1)(eslint@8.23.0)
       eslint-plugin-jsx-a11y: 6.6.1(eslint@8.23.0)
       eslint-plugin-react: 7.31.1(eslint@8.23.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.23.0)
@@ -9568,7 +9530,7 @@ packages:
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.23.0
-      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.48.1)(eslint@8.23.0)
+      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.36.1)(eslint-import-resolver-typescript@2.7.1)(eslint@8.23.0)
       glob: 7.2.3
       is-glob: 4.0.3
       resolve: 1.22.6
@@ -9577,7 +9539,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils@2.7.4(@typescript-eslint/parser@5.48.1)(eslint-import-resolver-node@0.3.6)(eslint@8.23.0):
+  /eslint-module-utils@2.7.4(@typescript-eslint/parser@5.36.1)(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@2.7.1)(eslint@8.23.0):
     resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -9598,15 +9560,16 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.48.1(eslint@8.31.0)(typescript@4.9.4)
+      '@typescript-eslint/parser': 5.36.1(eslint@8.23.0)(typescript@4.9.4)
       debug: 3.2.7(supports-color@8.1.1)
       eslint: 8.23.0
       eslint-import-resolver-node: 0.3.6
+      eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.26.0)(eslint@8.23.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.48.1)(eslint@8.23.0):
+  /eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.36.1)(eslint-import-resolver-typescript@2.7.1)(eslint@8.23.0):
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -9616,14 +9579,14 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.48.1(eslint@8.31.0)(typescript@4.9.4)
+      '@typescript-eslint/parser': 5.36.1(eslint@8.23.0)(typescript@4.9.4)
       array-includes: 3.1.5
       array.prototype.flat: 1.3.0
       debug: 2.6.9
       doctrine: 2.1.0
       eslint: 8.23.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.48.1)(eslint-import-resolver-node@0.3.6)(eslint@8.23.0)
+      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.36.1)(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@2.7.1)(eslint@8.23.0)
       has: 1.0.3
       is-core-module: 2.10.0
       is-glob: 4.0.3
@@ -10528,7 +10491,7 @@ packages:
       semver: 7.5.4
       tapable: 2.2.1
       typescript: 4.9.4
-      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
+      webpack: 5.88.2(@swc/core@1.3.83)
     dev: true
 
   /form-data@2.3.3:
@@ -11096,7 +11059,7 @@ packages:
     engines: {node: '>=14'}
     dev: false
 
-  /groqd-playground@0.0.12(@sanity/icons@2.3.1)(@sanity/ui@1.3.2)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(sanity@3.9.1)(styled-components@5.3.10):
+  /groqd-playground@0.0.12(@sanity/ui@1.3.2)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(sanity@3.9.1)(styled-components@5.3.10):
     resolution: {integrity: sha512-Chlup0BRl1Rg5RAYXdwtvcJlI9MMVjfoVpJJLBBLZzBuhiqdgYIwz9+URfvmHN5k/UPYNFVVYa5tSoeHnFFquQ==}
     peerDependencies:
       '@sanity/icons': ^2.3.1
@@ -11107,7 +11070,6 @@ packages:
       sanity: ^3.0.0
       styled-components: ^5.3.9
     dependencies:
-      '@sanity/icons': 2.3.1(react@18.2.0)
       '@sanity/ui': 1.3.2(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.10)
       '@uiw/react-split': 5.8.10(react-dom@18.2.0)(react@18.2.0)
       groqd: 0.15.4
@@ -11333,7 +11295,7 @@ packages:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
+      webpack: 5.88.2(@swc/core@1.3.83)
     dev: true
 
   /htmlparser2@3.10.1:
@@ -11562,7 +11524,7 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /inquirer-autocomplete-prompt@3.0.0(inquirer@9.2.11):
+  /inquirer-autocomplete-prompt@3.0.0:
     resolution: {integrity: sha512-nsPWllBQB3qhvpVgV1UIJN4xo3yz7Qv8y1+zrNVpJUNPxtUZ7btCum/4UCAs5apPCe/FVhKH1V6Wx0cAwkreyg==}
     engines: {node: '>=12'}
     peerDependencies:
@@ -11570,7 +11532,6 @@ packages:
     dependencies:
       ansi-escapes: 6.2.0
       figures: 5.0.0
-      inquirer: 9.2.11
       picocolors: 1.0.0
       run-async: 2.4.1
       rxjs: 7.8.1
@@ -14009,7 +13970,7 @@ packages:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
     dev: true
 
-  /next-sanity@4.2.0(@sanity/icons@2.3.1)(@sanity/types@3.9.1)(@sanity/ui@1.3.2)(@types/styled-components@5.1.29)(next@13.4.0)(react@18.2.0)(sanity@3.9.1)(styled-components@5.3.10):
+  /next-sanity@4.2.0(@sanity/ui@1.3.2)(next@13.4.0)(react@18.2.0)(sanity@3.9.1)(styled-components@5.3.10):
     resolution: {integrity: sha512-4GNEgXXDWPlvXqdJaAfKBR8BNvwQqUCynJ9GCgL6tVGcfZvcAImyZkzLTXj75PTZDPDcc7OfKHXg+XbmbUp7hA==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -14023,14 +13984,11 @@ packages:
       styled-components: ^5.2
     dependencies:
       '@sanity/client': 5.4.2
-      '@sanity/icons': 2.3.1(react@18.2.0)
       '@sanity/preview-kit': 1.4.0(react@18.2.0)
-      '@sanity/types': 3.9.1
       '@sanity/ui': 1.3.2(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.10)
       '@sanity/webhook': 2.0.0
-      '@types/styled-components': 5.1.29
       groq: 3.9.1
-      next: 13.4.0(@babel/core@7.22.15)(react-dom@18.2.0)(react@18.2.0)
+      next: 13.4.0(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       sanity: 3.9.1(@types/node@18.7.14)(@types/react@18.0.18)(react-dom@18.2.0)(react@18.2.0)(styled-components@5.3.10)
       styled-components: 5.3.10(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
@@ -14038,7 +13996,7 @@ packages:
       - supports-color
     dev: false
 
-  /next@13.4.0(@babel/core@7.22.15)(react-dom@18.2.0)(react@18.2.0):
+  /next@13.4.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-y3E+2ZjiVrphkz7zcJvd2rEG6miOekI8krPfWV4AZZ9TaF0LDuFdP/f+RQ5M9wRvsz6GWw8k8+7jsO860GxSqg==}
     engines: {node: '>=16.8.0'}
     hasBin: true
@@ -14153,7 +14111,7 @@ packages:
       upper-case: 2.0.2
     dev: true
 
-  /node-polyfill-webpack-plugin@2.0.1(webpack@5.88.2):
+  /node-polyfill-webpack-plugin@2.0.1:
     resolution: {integrity: sha512-ZUMiCnZkP1LF0Th2caY6J/eKKoA0TefpoVa68m/LQU1I/mE8rGt4fNYGgNuCcK+aG8P8P43nbeJ2RqJMOL/Y1A==}
     engines: {node: '>=12'}
     peerDependencies:
@@ -14184,7 +14142,6 @@ packages:
       url: 0.11.1
       util: 0.12.4
       vm-browserify: 1.1.2
-      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
     dev: true
 
   /node-preload@0.2.1:
@@ -14995,7 +14952,7 @@ packages:
       postcss: 8.4.16
       yaml: 1.10.2
 
-  /postcss-loader@7.3.3(postcss@8.4.21)(typescript@4.9.4)(webpack@5.88.2):
+  /postcss-loader@7.3.3(postcss@8.4.21)(typescript@4.9.4):
     resolution: {integrity: sha512-YgO/yhtevGO/vJePCQmTxiaEwER94LABZN0ZMT4A0vsak9TpO+RvKRs7EmJ8peIlB9xfXCsS7M8LjqncsUZ5HA==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -15006,7 +14963,6 @@ packages:
       jiti: 1.20.0
       postcss: 8.4.21
       semver: 7.3.8
-      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -16206,7 +16162,7 @@ packages:
       - utf-8-validate
     dev: false
 
-  /sass-loader@12.6.0(webpack@5.88.2):
+  /sass-loader@12.6.0:
     resolution: {integrity: sha512-oLTaH0YCtX4cfnJZxKSLAyglED0naiYfNG1iXfU5w1LNZ+ukoA5DtyDIN5zmKVZwYNJP4KRc5Y3hkWga+7tYfA==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -16227,7 +16183,6 @@ packages:
     dependencies:
       klona: 2.0.6
       neo-async: 2.6.2
-      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
     dev: true
 
   /saxes@6.0.0:
@@ -16256,7 +16211,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.12.0
-      ajv-formats: 2.1.1(ajv@8.12.0)
+      ajv-formats: 2.1.1
       ajv-keywords: 5.1.0(ajv@8.12.0)
     dev: true
 
@@ -16911,7 +16866,7 @@ packages:
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
+      webpack: 5.88.2(@swc/core@1.3.83)
     dev: true
 
   /style-mod@4.0.0:
@@ -17010,7 +16965,7 @@ packages:
       webpack: '>=2'
     dependencies:
       '@swc/core': 1.3.83
-      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
+      webpack: 5.88.2(@swc/core@1.3.83)
     dev: true
 
   /symbol-tree@3.2.4:
@@ -17124,7 +17079,7 @@ packages:
       supports-hyperlinks: 2.3.0
     dev: true
 
-  /terser-webpack-plugin@5.3.9(@swc/core@1.3.83)(esbuild@0.16.17)(webpack@5.88.2):
+  /terser-webpack-plugin@5.3.9(@swc/core@1.3.83)(webpack@5.88.2):
     resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -17142,12 +17097,35 @@ packages:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.17
       '@swc/core': 1.3.83
-      esbuild: 0.16.17
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.19.4
-      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
+      webpack: 5.88.2(@swc/core@1.3.83)
+    dev: true
+
+  /terser-webpack-plugin@5.3.9(webpack@5.88.2):
+    resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@swc/core': '*'
+      esbuild: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      esbuild:
+        optional: true
+      uglify-js:
+        optional: true
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.17
+      jest-worker: 27.5.1
+      schema-utils: 3.3.0
+      serialize-javascript: 6.0.1
+      terser: 5.19.4
+      webpack: 5.88.2
     dev: true
 
   /terser@5.19.4:
@@ -17915,7 +17893,7 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.2.0
-      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
+      webpack: 5.88.2(@swc/core@1.3.83)
     dev: true
 
   /webpack-hot-middleware@2.25.4:
@@ -17935,7 +17913,7 @@ packages:
     resolution: {integrity: sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==}
     dev: true
 
-  /webpack@5.88.2(@swc/core@1.3.83)(esbuild@0.16.17):
+  /webpack@5.88.2:
     resolution: {integrity: sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -17966,7 +17944,47 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(@swc/core@1.3.83)(esbuild@0.16.17)(webpack@5.88.2)
+      terser-webpack-plugin: 5.3.9(webpack@5.88.2)
+      watchpack: 2.4.0
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+    dev: true
+
+  /webpack@5.88.2(@swc/core@1.3.83):
+    resolution: {integrity: sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
+    dependencies:
+      '@types/eslint-scope': 3.7.4
+      '@types/estree': 1.0.1
+      '@webassemblyjs/ast': 1.11.6
+      '@webassemblyjs/wasm-edit': 1.11.6
+      '@webassemblyjs/wasm-parser': 1.11.6
+      acorn: 8.10.0
+      acorn-import-assertions: 1.9.0(acorn@8.10.0)
+      browserslist: 4.21.10
+      chrome-trace-event: 1.0.3
+      enhanced-resolve: 5.15.0
+      es-module-lexer: 1.3.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.10
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.0
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 3.3.0
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.9(@swc/core@1.3.83)(webpack@5.88.2)
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: '6.0'
 
 settings:
-  autoInstallPeers: false
+  autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 importers:
@@ -31,7 +31,7 @@ importers:
         version: 8.0.3
       inquirer-autocomplete-prompt:
         specifier: ^3.0.0
-        version: 3.0.0
+        version: 3.0.0(inquirer@9.2.11)
       lint-staged:
         specifier: ^13.1.0
         version: 13.1.0
@@ -73,7 +73,7 @@ importers:
         version: 1.3.2(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.10)
       '@sanity/vision':
         specifier: ^3.9.1
-        version: 3.9.1(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.10)
+        version: 3.9.1(@babel/runtime@7.22.15)(@codemirror/lint@6.1.0)(@codemirror/state@6.2.0)(@codemirror/theme-one-dark@6.1.0)(@lezer/common@1.0.2)(codemirror@6.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.10)
       '@sanity/webhook':
         specifier: ^2.0.0
         version: 2.0.0
@@ -109,7 +109,7 @@ importers:
         version: 0.15.4
       groqd-playground:
         specifier: ^0.0.12
-        version: 0.0.12(@sanity/ui@1.3.2)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(sanity@3.9.1)(styled-components@5.3.10)
+        version: 0.0.12(@sanity/icons@2.3.1)(@sanity/ui@1.3.2)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(sanity@3.9.1)(styled-components@5.3.10)
       jsdom:
         specifier: ^20.0.0
         version: 20.0.0
@@ -118,10 +118,10 @@ importers:
         version: 4.0.8
       next:
         specifier: ^13.4.0
-        version: 13.4.0(react-dom@18.2.0)(react@18.2.0)
+        version: 13.4.0(@babel/core@7.22.15)(react-dom@18.2.0)(react@18.2.0)
       next-sanity:
         specifier: ^4.2.0
-        version: 4.2.0(@sanity/ui@1.3.2)(next@13.4.0)(react@18.2.0)(sanity@3.9.1)(styled-components@5.3.10)
+        version: 4.2.0(@sanity/icons@2.3.1)(@sanity/types@3.9.1)(@sanity/ui@1.3.2)(@types/styled-components@5.1.26)(next@13.4.0)(react@18.2.0)(sanity@3.9.1)(styled-components@5.3.10)
       node-fetch:
         specifier: ^3.2.10
         version: 3.2.10
@@ -173,7 +173,7 @@ importers:
         version: 0.2.2(jest@29.3.1)
       '@storybook/nextjs':
         specifier: ^7.4.0
-        version: 7.4.0(@types/react-dom@18.0.6)(@types/react@18.0.18)(next@13.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.4)
+        version: 7.4.0(@swc/core@1.3.83)(@types/react-dom@18.0.6)(@types/react@18.0.18)(esbuild@0.16.17)(next@13.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.4)(webpack@5.88.2)
       '@storybook/react':
         specifier: ^7.4.0
         version: 7.4.0(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.4)
@@ -1813,8 +1813,13 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
-  /@codemirror/autocomplete@6.4.0:
+  /@codemirror/autocomplete@6.4.0(@codemirror/language@6.4.0)(@codemirror/state@6.2.0)(@codemirror/view@6.7.3)(@lezer/common@1.0.2):
     resolution: {integrity: sha512-HLF2PnZAm1s4kGs30EiqKMgD7XsYaQ0XJnMR0rofEWQ5t5D60SfqpDIkIh1ze5tiEbyUWm8+VJ6W1/erVvBMIA==}
+    peerDependencies:
+      '@codemirror/language': ^6.0.0
+      '@codemirror/state': ^6.0.0
+      '@codemirror/view': ^6.0.0
+      '@lezer/common': ^1.0.0
     dependencies:
       '@codemirror/language': 6.4.0
       '@codemirror/state': 6.2.0
@@ -1834,7 +1839,7 @@ packages:
   /@codemirror/lang-javascript@6.1.2:
     resolution: {integrity: sha512-OcwLfZXdQ1OHrLiIcKCn7MqZ7nx205CMKlhe+vL88pe2ymhT9+2P+QhwkYGxMICj8TDHyp8HFKVwpiisUT7iEQ==}
     dependencies:
-      '@codemirror/autocomplete': 6.4.0
+      '@codemirror/autocomplete': 6.4.0(@codemirror/language@6.4.0)(@codemirror/state@6.2.0)(@codemirror/view@6.7.3)(@lezer/common@1.0.2)
       '@codemirror/language': 6.4.0
       '@codemirror/lint': 6.1.0
       '@codemirror/state': 6.2.0
@@ -3330,7 +3335,7 @@ packages:
       react-refresh: 0.11.0
       schema-utils: 3.3.0
       source-map: 0.7.4
-      webpack: 5.88.2
+      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
     dev: true
 
   /@portabletext/react@1.0.6(react@18.2.0):
@@ -4277,7 +4282,7 @@ packages:
     resolution: {integrity: sha512-A6M86wIAuM2EYzTxUpPkZmZug0PJDmbZK5a7E5VfkWzJFKRvHNa3ZmVGXijHE7M/1KOJH+t1KQeqLkfMsYq4Ig==}
     dependencies:
       '@sanity/client': 5.4.2
-      '@types/react': 18.2.0
+      '@types/react': 18.0.27
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -4332,13 +4337,13 @@ packages:
       - supports-color
     dev: false
 
-  /@sanity/vision@3.9.1(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.10):
+  /@sanity/vision@3.9.1(@babel/runtime@7.22.15)(@codemirror/lint@6.1.0)(@codemirror/state@6.2.0)(@codemirror/theme-one-dark@6.1.0)(@lezer/common@1.0.2)(codemirror@6.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.10):
     resolution: {integrity: sha512-pRcaierrdo6rqL+59UBuNnMfATX5iobvaijFS/okqjdgloZHfhstph0W4GUp79cqxjZFi9qQffa2lguU3pWcjA==}
     peerDependencies:
       react: ^18
       styled-components: ^5.2
     dependencies:
-      '@codemirror/autocomplete': 6.4.0
+      '@codemirror/autocomplete': 6.4.0(@codemirror/language@6.4.0)(@codemirror/state@6.2.0)(@codemirror/view@6.7.3)(@lezer/common@1.0.2)
       '@codemirror/commands': 6.2.0
       '@codemirror/lang-javascript': 6.1.2
       '@codemirror/language': 6.4.0
@@ -4351,7 +4356,7 @@ packages:
       '@sanity/color': 2.2.2
       '@sanity/icons': 2.3.1(react@18.2.0)
       '@sanity/ui': 1.3.2(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.10)
-      '@uiw/react-codemirror': 4.19.7(@codemirror/autocomplete@6.4.0)(@codemirror/language@6.4.0)(@codemirror/search@6.2.3)(@codemirror/view@6.7.3)(react-dom@18.2.0)(react@18.2.0)
+      '@uiw/react-codemirror': 4.19.7(@babel/runtime@7.22.15)(@codemirror/autocomplete@6.4.0)(@codemirror/language@6.4.0)(@codemirror/lint@6.1.0)(@codemirror/search@6.2.3)(@codemirror/state@6.2.0)(@codemirror/theme-one-dark@6.1.0)(@codemirror/view@6.7.3)(codemirror@6.0.1)(react-dom@18.2.0)(react@18.2.0)
       hashlru: 2.3.0
       is-hotkey: 0.1.8
       json5: 2.2.3
@@ -4359,6 +4364,12 @@ packages:
       react: 18.2.0
       styled-components: 5.3.10(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
     transitivePeerDependencies:
+      - '@babel/runtime'
+      - '@codemirror/lint'
+      - '@codemirror/state'
+      - '@codemirror/theme-one-dark'
+      - '@lezer/common'
+      - codemirror
       - react-dom
       - react-is
     dev: false
@@ -4803,7 +4814,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/builder-webpack5@7.4.0(typescript@4.9.4):
+  /@storybook/builder-webpack5@7.4.0(esbuild@0.16.17)(typescript@4.9.4):
     resolution: {integrity: sha512-CYeXppqGACzDUpLCFvWvwD7IjN7VNi7+nwQ1uRNgW2NgBMOIldZe+gcTXcc0BuHyIitU5/vvquYM0qjis05LYw==}
     peerDependencies:
       typescript: '*'
@@ -4838,13 +4849,13 @@ packages:
       semver: 7.3.8
       style-loader: 3.3.3(webpack@5.88.2)
       swc-loader: 0.2.3(@swc/core@1.3.83)(webpack@5.88.2)
-      terser-webpack-plugin: 5.3.9(@swc/core@1.3.83)(webpack@5.88.2)
+      terser-webpack-plugin: 5.3.9(@swc/core@1.3.83)(esbuild@0.16.17)(webpack@5.88.2)
       ts-dedent: 2.2.0
       typescript: 4.9.4
       url: 0.11.1
       util: 0.12.4
       util-deprecate: 1.0.2
-      webpack: 5.88.2(@swc/core@1.3.83)
+      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
       webpack-dev-middleware: 6.1.1(webpack@5.88.2)
       webpack-hot-middleware: 2.25.4
       webpack-virtual-modules: 0.5.0
@@ -5184,7 +5195,7 @@ packages:
       memoizerific: 1.11.3
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      semver: 7.5.4
+      semver: 7.3.8
       store2: 2.14.2
       telejson: 7.2.0
       ts-dedent: 2.2.0
@@ -5198,7 +5209,7 @@ packages:
     resolution: {integrity: sha512-TXJJd5RAKakWx4BtpwvSNdgTDkKM6RkXU8GK34S/LhidQ5Pjz3wcnqb0TxEkfhK/ztbP8nKHqXFwLfa2CYkvQw==}
     dev: true
 
-  /@storybook/nextjs@7.4.0(@types/react-dom@18.0.6)(@types/react@18.0.18)(next@13.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.4):
+  /@storybook/nextjs@7.4.0(@swc/core@1.3.83)(@types/react-dom@18.0.6)(@types/react@18.0.18)(esbuild@0.16.17)(next@13.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.4)(webpack@5.88.2):
     resolution: {integrity: sha512-nGmer4Hu1/XX3+XyxfAkQ9d16Qsj467aLc7MTNQ2uFyYAksCqT3bvznooUOcD/X5NfoyL2YA78OczGdt1HFFpQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -5232,10 +5243,10 @@ packages:
       '@babel/preset-typescript': 7.22.15(@babel/core@7.22.15)
       '@babel/runtime': 7.22.15
       '@storybook/addon-actions': 7.4.0(@types/react-dom@18.0.6)(@types/react@18.0.18)(react-dom@18.2.0)(react@18.2.0)
-      '@storybook/builder-webpack5': 7.4.0(typescript@4.9.4)
+      '@storybook/builder-webpack5': 7.4.0(esbuild@0.16.17)(typescript@4.9.4)
       '@storybook/core-common': 7.4.0
       '@storybook/node-logger': 7.4.0
-      '@storybook/preset-react-webpack': 7.4.0(@babel/core@7.22.15)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.4)
+      '@storybook/preset-react-webpack': 7.4.0(@babel/core@7.22.15)(@swc/core@1.3.83)(esbuild@0.16.17)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.4)
       '@storybook/preview-api': 7.4.0
       '@storybook/react': 7.4.0(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.4)
       '@types/node': 16.18.48
@@ -5244,15 +5255,15 @@ packages:
       fs-extra: 11.1.1
       image-size: 1.0.2
       loader-utils: 3.2.1
-      next: 13.4.0(react-dom@18.2.0)(react@18.2.0)
-      node-polyfill-webpack-plugin: 2.0.1
+      next: 13.4.0(@babel/core@7.22.15)(react-dom@18.2.0)(react@18.2.0)
+      node-polyfill-webpack-plugin: 2.0.1(webpack@5.88.2)
       pnp-webpack-plugin: 1.7.0(typescript@4.9.4)
       postcss: 8.4.21
-      postcss-loader: 7.3.3(postcss@8.4.21)(typescript@4.9.4)
+      postcss-loader: 7.3.3(postcss@8.4.21)(typescript@4.9.4)(webpack@5.88.2)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       resolve-url-loader: 5.0.0
-      sass-loader: 12.6.0
+      sass-loader: 12.6.0(webpack@5.88.2)
       semver: 7.3.8
       style-loader: 3.3.3(webpack@5.88.2)
       styled-jsx: 5.1.1(@babel/core@7.22.15)(react@18.2.0)
@@ -5260,6 +5271,7 @@ packages:
       tsconfig-paths: 4.2.0
       tsconfig-paths-webpack-plugin: 4.1.0
       typescript: 4.9.4
+      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/helpers'
@@ -5291,7 +5303,7 @@ packages:
     resolution: {integrity: sha512-ZVBZggqkuj7ysfuHSCd/J7ovWV06zY9uWf+VU+Zw7ZeojDT8QHFrCurPsN7D9679j9vRU1/kSzqvAiStALS33g==}
     dev: true
 
-  /@storybook/preset-react-webpack@7.4.0(@babel/core@7.22.15)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.4):
+  /@storybook/preset-react-webpack@7.4.0(@babel/core@7.22.15)(@swc/core@1.3.83)(esbuild@0.16.17)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.4):
     resolution: {integrity: sha512-9iZ9lvhRUYtxXmJMqR7txNyatrHryqo6FSKzfpUzmcCySn3d7mu9I6LEPxEir43TkPnBio3W4EsbvtIhjJ5ekA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -5324,7 +5336,7 @@ packages:
       react-refresh: 0.11.0
       semver: 7.3.8
       typescript: 4.9.4
-      webpack: 5.88.2
+      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
     transitivePeerDependencies:
       - '@swc/core'
       - '@types/webpack'
@@ -5377,7 +5389,7 @@ packages:
       react-docgen-typescript: 2.2.2(typescript@4.9.4)
       tslib: 2.4.1
       typescript: 4.9.4
-      webpack: 5.88.2
+      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5530,7 +5542,7 @@ packages:
       '@storybook/channels': 7.4.0
       '@types/babel__core': 7.20.0
       '@types/express': 4.17.17
-      '@types/react': 16.14.50
+      '@types/react': 16.14.46
       file-system-cache: 2.3.0
     dev: true
 
@@ -5986,6 +5998,13 @@ packages:
       '@types/unist': 2.0.6
     dev: false
 
+  /@types/hoist-non-react-statics@3.3.1:
+    resolution: {integrity: sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==}
+    dependencies:
+      '@types/react': 18.0.18
+      hoist-non-react-statics: 3.3.2
+    dev: false
+
   /@types/html-minifier-terser@6.1.0:
     resolution: {integrity: sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==}
     dev: true
@@ -6161,8 +6180,8 @@ packages:
       '@types/react': 18.0.18
     dev: false
 
-  /@types/react@16.14.50:
-    resolution: {integrity: sha512-7TWZ/HjhXsRK3BbhSFxTinbSft3sUXJAU3ONngT0rpcKJaIOlxkRke4bidqQTopUbEv1ApC5nlSEkIpX43MkTg==}
+  /@types/react@16.14.46:
+    resolution: {integrity: sha512-Am4pyXMrr6cWWw/TN3oqHtEZl0j+G6Up/O8m65+xF/3ZaUgkv1GAtTPWw4yNRmH0HJXmur6xKCKoMo3rBGynuw==}
     dependencies:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2
@@ -6174,10 +6193,10 @@ packages:
     dependencies:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2
-      csstype: 3.1.1
+      csstype: 3.1.0
 
-  /@types/react@18.2.0:
-    resolution: {integrity: sha512-0FLj93y5USLHdnhIhABk83rm8XEGA7kH3cr+YUlvxoUGp1xNt/DINUMvqPxLyOQMzLmZe8i4RTHbvb8MC7NmrA==}
+  /@types/react@18.0.27:
+    resolution: {integrity: sha512-3vtRKHgVxu3Jp9t718R9BuzoD4NcQ8YJ5XRzsSKxNDiDonD2MXIT1TmSkenxuCycZJoQT5d2vE8LwWJxBC1gmA==}
     dependencies:
       '@types/prop-types': 15.7.5
       '@types/scheduler': 0.16.2
@@ -6231,6 +6250,14 @@ packages:
   /@types/stack-utils@2.0.1:
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
     dev: true
+
+  /@types/styled-components@5.1.26:
+    resolution: {integrity: sha512-KuKJ9Z6xb93uJiIyxo/+ksS7yLjS1KzG6iv5i78dhVg/X3u5t1H7juRWqVmodIdz6wGVaIApo1u01kmFRdJHVw==}
+    dependencies:
+      '@types/hoist-non-react-statics': 3.3.1
+      '@types/react': 18.0.18
+      csstype: 3.1.1
+    dev: false
 
   /@types/testing-library__jest-dom@5.14.5:
     resolution: {integrity: sha512-SBwbxYoyPIvxHbeHxTZX2Pe/74F/tX2/D3mMvzabdeJ25bBojfW0TyB8BHrbq/9zaaKICJZjLP+8r6AeZMFCuQ==}
@@ -6499,16 +6526,18 @@ packages:
       eslint-visitor-keys: 3.3.0
     dev: true
 
-  /@uiw/codemirror-extensions-basic-setup@4.19.7(@codemirror/autocomplete@6.4.0)(@codemirror/commands@6.2.0)(@codemirror/language@6.4.0)(@codemirror/search@6.2.3)(@codemirror/view@6.7.3):
+  /@uiw/codemirror-extensions-basic-setup@4.19.7(@codemirror/autocomplete@6.4.0)(@codemirror/commands@6.2.0)(@codemirror/language@6.4.0)(@codemirror/lint@6.1.0)(@codemirror/search@6.2.3)(@codemirror/state@6.2.0)(@codemirror/view@6.7.3):
     resolution: {integrity: sha512-pk0JTFJAZOGxouBB1pdBtb59qKibO9DW4hER4VSFGBGW3TBDeXUwL/gKujhRpySHG2MtG09cgt4a3XOFIWwXTw==}
     peerDependencies:
       '@codemirror/autocomplete': '>=6.0.0'
       '@codemirror/commands': '>=6.0.0'
       '@codemirror/language': '>=6.0.0'
+      '@codemirror/lint': '>=6.0.0'
       '@codemirror/search': '>=6.0.0'
+      '@codemirror/state': '>=6.0.0'
       '@codemirror/view': '>=6.0.0'
     dependencies:
-      '@codemirror/autocomplete': 6.4.0
+      '@codemirror/autocomplete': 6.4.0(@codemirror/language@6.4.0)(@codemirror/state@6.2.0)(@codemirror/view@6.7.3)(@lezer/common@1.0.2)
       '@codemirror/commands': 6.2.0
       '@codemirror/language': 6.4.0
       '@codemirror/lint': 6.1.0
@@ -6517,10 +6546,14 @@ packages:
       '@codemirror/view': 6.7.3
     dev: false
 
-  /@uiw/react-codemirror@4.19.7(@codemirror/autocomplete@6.4.0)(@codemirror/language@6.4.0)(@codemirror/search@6.2.3)(@codemirror/view@6.7.3)(react-dom@18.2.0)(react@18.2.0):
+  /@uiw/react-codemirror@4.19.7(@babel/runtime@7.22.15)(@codemirror/autocomplete@6.4.0)(@codemirror/language@6.4.0)(@codemirror/lint@6.1.0)(@codemirror/search@6.2.3)(@codemirror/state@6.2.0)(@codemirror/theme-one-dark@6.1.0)(@codemirror/view@6.7.3)(codemirror@6.0.1)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-IHvpYWVSdiaHX0Fk6oY6YyAJigDnyvSpWKNUTRzsMNxB+8/wqZ8lior4TprXH0zyLxW5F1+bTyifFFTeg+X3Sw==}
     peerDependencies:
+      '@babel/runtime': '>=7.11.0'
+      '@codemirror/state': '>=6.0.0'
+      '@codemirror/theme-one-dark': '>=6.0.0'
       '@codemirror/view': '>=6.0.0'
+      codemirror: '>=6.0.0'
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
     dependencies:
@@ -6529,13 +6562,14 @@ packages:
       '@codemirror/state': 6.2.0
       '@codemirror/theme-one-dark': 6.1.0
       '@codemirror/view': 6.7.3
-      '@uiw/codemirror-extensions-basic-setup': 4.19.7(@codemirror/autocomplete@6.4.0)(@codemirror/commands@6.2.0)(@codemirror/language@6.4.0)(@codemirror/search@6.2.3)(@codemirror/view@6.7.3)
-      codemirror: 6.0.1
+      '@uiw/codemirror-extensions-basic-setup': 4.19.7(@codemirror/autocomplete@6.4.0)(@codemirror/commands@6.2.0)(@codemirror/language@6.4.0)(@codemirror/lint@6.1.0)(@codemirror/search@6.2.3)(@codemirror/state@6.2.0)(@codemirror/view@6.7.3)
+      codemirror: 6.0.1(@lezer/common@1.0.2)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - '@codemirror/autocomplete'
       - '@codemirror/language'
+      - '@codemirror/lint'
       - '@codemirror/search'
     dev: false
 
@@ -6768,12 +6802,12 @@ packages:
       acorn: 7.4.1
       acorn-walk: 7.2.0
 
-  /acorn-import-assertions@1.9.0(acorn@8.10.0):
+  /acorn-import-assertions@1.9.0(acorn@8.8.1):
     resolution: {integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==}
     peerDependencies:
       acorn: ^8
     dependencies:
-      acorn: 8.10.0
+      acorn: 8.8.1
     dev: true
 
   /acorn-jsx@5.3.2(acorn@7.4.1):
@@ -6861,8 +6895,10 @@ packages:
       indent-string: 5.0.0
     dev: true
 
-  /ajv-formats@2.1.1:
+  /ajv-formats@2.1.1(ajv@8.12.0):
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -7314,7 +7350,7 @@ packages:
       '@babel/core': 7.22.15
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.88.2(@swc/core@1.3.83)
+      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
     dev: true
 
   /babel-plugin-add-react-displayname@0.0.5:
@@ -8074,16 +8110,18 @@ packages:
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
     dev: true
 
-  /codemirror@6.0.1:
+  /codemirror@6.0.1(@lezer/common@1.0.2):
     resolution: {integrity: sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==}
     dependencies:
-      '@codemirror/autocomplete': 6.4.0
+      '@codemirror/autocomplete': 6.4.0(@codemirror/language@6.4.0)(@codemirror/state@6.2.0)(@codemirror/view@6.7.3)(@lezer/common@1.0.2)
       '@codemirror/commands': 6.2.0
       '@codemirror/language': 6.4.0
       '@codemirror/lint': 6.1.0
       '@codemirror/search': 6.2.3
       '@codemirror/state': 6.2.0
       '@codemirror/view': 6.7.3
+    transitivePeerDependencies:
+      - '@lezer/common'
     dev: false
 
   /collect-v8-coverage@1.0.1:
@@ -8488,7 +8526,7 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.4.21)
       postcss-value-parser: 4.2.0
       semver: 7.3.8
-      webpack: 5.88.2(@swc/core@1.3.83)
+      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
     dev: true
 
   /css-select@4.3.0:
@@ -8521,7 +8559,6 @@ packages:
   /cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
-    hasBin: true
 
   /cssom@0.3.8:
     resolution: {integrity: sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==}
@@ -8534,6 +8571,9 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       cssom: 0.3.8
+
+  /csstype@3.1.0:
+    resolution: {integrity: sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==}
 
   /csstype@3.1.1:
     resolution: {integrity: sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==}
@@ -8890,7 +8930,6 @@ packages:
   /detective@5.2.1:
     resolution: {integrity: sha512-v9XE1zRnz1wRtgurGu0Bs8uHKFSTdteYZNbIPFVhUZ39L/S79ppMpdmVOZAnoz1jfEFodc48n6MX483Xo3t1yw==}
     engines: {node: '>=0.8.0'}
-    hasBin: true
     dependencies:
       acorn-node: 1.8.2
       defined: 1.0.0
@@ -9493,7 +9532,7 @@ packages:
       eslint: 8.23.0
       eslint-import-resolver-node: 0.3.6
       eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.26.0)(eslint@8.23.0)
-      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.36.1)(eslint-import-resolver-typescript@2.7.1)(eslint@8.23.0)
+      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.48.1)(eslint@8.23.0)
       eslint-plugin-jsx-a11y: 6.6.1(eslint@8.23.0)
       eslint-plugin-react: 7.31.1(eslint@8.23.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.23.0)
@@ -9530,7 +9569,7 @@ packages:
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.23.0
-      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.36.1)(eslint-import-resolver-typescript@2.7.1)(eslint@8.23.0)
+      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.48.1)(eslint@8.23.0)
       glob: 7.2.3
       is-glob: 4.0.3
       resolve: 1.22.6
@@ -9539,7 +9578,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils@2.7.4(@typescript-eslint/parser@5.36.1)(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@2.7.1)(eslint@8.23.0):
+  /eslint-module-utils@2.7.4(@typescript-eslint/parser@5.48.1)(eslint-import-resolver-node@0.3.6)(eslint@8.23.0):
     resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -9560,16 +9599,15 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.36.1(eslint@8.23.0)(typescript@4.9.4)
+      '@typescript-eslint/parser': 5.48.1(eslint@8.31.0)(typescript@4.9.4)
       debug: 3.2.7(supports-color@8.1.1)
       eslint: 8.23.0
       eslint-import-resolver-node: 0.3.6
-      eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.26.0)(eslint@8.23.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.36.1)(eslint-import-resolver-typescript@2.7.1)(eslint@8.23.0):
+  /eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.48.1)(eslint@8.23.0):
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -9579,14 +9617,14 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.36.1(eslint@8.23.0)(typescript@4.9.4)
+      '@typescript-eslint/parser': 5.48.1(eslint@8.31.0)(typescript@4.9.4)
       array-includes: 3.1.5
       array.prototype.flat: 1.3.0
       debug: 2.6.9
       doctrine: 2.1.0
       eslint: 8.23.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.36.1)(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@2.7.1)(eslint@8.23.0)
+      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.48.1)(eslint-import-resolver-node@0.3.6)(eslint@8.23.0)
       has: 1.0.3
       is-core-module: 2.10.0
       is-glob: 4.0.3
@@ -10154,6 +10192,16 @@ packages:
     resolution: {integrity: sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==}
     dev: true
 
+  /fast-glob@3.2.11:
+    resolution: {integrity: sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==}
+    engines: {node: '>=8.6.0'}
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.5
+
   /fast-glob@3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
     engines: {node: '>=8.6.0'}
@@ -10491,7 +10539,7 @@ packages:
       semver: 7.5.4
       tapable: 2.2.1
       typescript: 4.9.4
-      webpack: 5.88.2(@swc/core@1.3.83)
+      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
     dev: true
 
   /form-data@2.3.3:
@@ -11007,8 +11055,8 @@ packages:
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.3.1
-      ignore: 5.2.4
+      fast-glob: 3.2.11
+      ignore: 5.2.0
       merge2: 1.4.1
       slash: 3.0.0
     dev: true
@@ -11059,7 +11107,7 @@ packages:
     engines: {node: '>=14'}
     dev: false
 
-  /groqd-playground@0.0.12(@sanity/ui@1.3.2)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(sanity@3.9.1)(styled-components@5.3.10):
+  /groqd-playground@0.0.12(@sanity/icons@2.3.1)(@sanity/ui@1.3.2)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(sanity@3.9.1)(styled-components@5.3.10):
     resolution: {integrity: sha512-Chlup0BRl1Rg5RAYXdwtvcJlI9MMVjfoVpJJLBBLZzBuhiqdgYIwz9+URfvmHN5k/UPYNFVVYa5tSoeHnFFquQ==}
     peerDependencies:
       '@sanity/icons': ^2.3.1
@@ -11070,6 +11118,7 @@ packages:
       sanity: ^3.0.0
       styled-components: ^5.3.9
     dependencies:
+      '@sanity/icons': 2.3.1(react@18.2.0)
       '@sanity/ui': 1.3.2(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.10)
       '@uiw/react-split': 5.8.10(react-dom@18.2.0)(react@18.2.0)
       groqd: 0.15.4
@@ -11295,7 +11344,7 @@ packages:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.88.2(@swc/core@1.3.83)
+      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
     dev: true
 
   /htmlparser2@3.10.1:
@@ -11524,7 +11573,7 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /inquirer-autocomplete-prompt@3.0.0:
+  /inquirer-autocomplete-prompt@3.0.0(inquirer@9.2.11):
     resolution: {integrity: sha512-nsPWllBQB3qhvpVgV1UIJN4xo3yz7Qv8y1+zrNVpJUNPxtUZ7btCum/4UCAs5apPCe/FVhKH1V6Wx0cAwkreyg==}
     engines: {node: '>=12'}
     peerDependencies:
@@ -11532,6 +11581,7 @@ packages:
     dependencies:
       ansi-escapes: 6.2.0
       figures: 5.0.0
+      inquirer: 9.2.11
       picocolors: 1.0.0
       run-async: 2.4.1
       rxjs: 7.8.1
@@ -11702,7 +11752,6 @@ packages:
     resolution: {integrity: sha512-Erxj2n/LDAZ7H8WNJXd9tw38GYM3dv8rk8Zcs+jJuxYTW7sozH+SS8NtrSjVL1/vpLvWi1hxy96IzjJ3EHTJJg==}
     dependencies:
       has: 1.0.3
-    dev: true
 
   /is-core-module@2.13.0:
     resolution: {integrity: sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==}
@@ -13970,7 +14019,7 @@ packages:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
     dev: true
 
-  /next-sanity@4.2.0(@sanity/ui@1.3.2)(next@13.4.0)(react@18.2.0)(sanity@3.9.1)(styled-components@5.3.10):
+  /next-sanity@4.2.0(@sanity/icons@2.3.1)(@sanity/types@3.9.1)(@sanity/ui@1.3.2)(@types/styled-components@5.1.26)(next@13.4.0)(react@18.2.0)(sanity@3.9.1)(styled-components@5.3.10):
     resolution: {integrity: sha512-4GNEgXXDWPlvXqdJaAfKBR8BNvwQqUCynJ9GCgL6tVGcfZvcAImyZkzLTXj75PTZDPDcc7OfKHXg+XbmbUp7hA==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -13984,11 +14033,14 @@ packages:
       styled-components: ^5.2
     dependencies:
       '@sanity/client': 5.4.2
+      '@sanity/icons': 2.3.1(react@18.2.0)
       '@sanity/preview-kit': 1.4.0(react@18.2.0)
+      '@sanity/types': 3.9.1
       '@sanity/ui': 1.3.2(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.10)
       '@sanity/webhook': 2.0.0
+      '@types/styled-components': 5.1.26
       groq: 3.9.1
-      next: 13.4.0(react-dom@18.2.0)(react@18.2.0)
+      next: 13.4.0(@babel/core@7.22.15)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       sanity: 3.9.1(@types/node@18.7.14)(@types/react@18.0.18)(react-dom@18.2.0)(react@18.2.0)(styled-components@5.3.10)
       styled-components: 5.3.10(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
@@ -13996,7 +14048,7 @@ packages:
       - supports-color
     dev: false
 
-  /next@13.4.0(react-dom@18.2.0)(react@18.2.0):
+  /next@13.4.0(@babel/core@7.22.15)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-y3E+2ZjiVrphkz7zcJvd2rEG6miOekI8krPfWV4AZZ9TaF0LDuFdP/f+RQ5M9wRvsz6GWw8k8+7jsO860GxSqg==}
     engines: {node: '>=16.8.0'}
     hasBin: true
@@ -14111,7 +14163,7 @@ packages:
       upper-case: 2.0.2
     dev: true
 
-  /node-polyfill-webpack-plugin@2.0.1:
+  /node-polyfill-webpack-plugin@2.0.1(webpack@5.88.2):
     resolution: {integrity: sha512-ZUMiCnZkP1LF0Th2caY6J/eKKoA0TefpoVa68m/LQU1I/mE8rGt4fNYGgNuCcK+aG8P8P43nbeJ2RqJMOL/Y1A==}
     engines: {node: '>=12'}
     peerDependencies:
@@ -14142,6 +14194,7 @@ packages:
       url: 0.11.1
       util: 0.12.4
       vm-browserify: 1.1.2
+      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
     dev: true
 
   /node-preload@0.2.1:
@@ -14952,7 +15005,7 @@ packages:
       postcss: 8.4.16
       yaml: 1.10.2
 
-  /postcss-loader@7.3.3(postcss@8.4.21)(typescript@4.9.4):
+  /postcss-loader@7.3.3(postcss@8.4.21)(typescript@4.9.4)(webpack@5.88.2):
     resolution: {integrity: sha512-YgO/yhtevGO/vJePCQmTxiaEwER94LABZN0ZMT4A0vsak9TpO+RvKRs7EmJ8peIlB9xfXCsS7M8LjqncsUZ5HA==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -14963,6 +15016,7 @@ packages:
       jiti: 1.20.0
       postcss: 8.4.21
       semver: 7.3.8
+      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -15869,6 +15923,14 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
+  /resolve@1.22.1:
+    resolution: {integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==}
+    hasBin: true
+    dependencies:
+      is-core-module: 2.10.0
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
   /resolve@1.22.6:
     resolution: {integrity: sha512-njhxM7mV12JfufShqGy3Rz8j11RPdLy4xi15UurGJeoHLfJpVXKdh3ueuOqbYUcDZnffr6X739JBo5LzyahEsw==}
     hasBin: true
@@ -16162,7 +16224,7 @@ packages:
       - utf-8-validate
     dev: false
 
-  /sass-loader@12.6.0:
+  /sass-loader@12.6.0(webpack@5.88.2):
     resolution: {integrity: sha512-oLTaH0YCtX4cfnJZxKSLAyglED0naiYfNG1iXfU5w1LNZ+ukoA5DtyDIN5zmKVZwYNJP4KRc5Y3hkWga+7tYfA==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -16183,6 +16245,7 @@ packages:
     dependencies:
       klona: 2.0.6
       neo-async: 2.6.2
+      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
     dev: true
 
   /saxes@6.0.0:
@@ -16211,7 +16274,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.12.0
-      ajv-formats: 2.1.1
+      ajv-formats: 2.1.1(ajv@8.12.0)
       ajv-keywords: 5.1.0(ajv@8.12.0)
     dev: true
 
@@ -16866,7 +16929,7 @@ packages:
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      webpack: 5.88.2(@swc/core@1.3.83)
+      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
     dev: true
 
   /style-mod@4.0.0:
@@ -16965,7 +17028,7 @@ packages:
       webpack: '>=2'
     dependencies:
       '@swc/core': 1.3.83
-      webpack: 5.88.2(@swc/core@1.3.83)
+      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
     dev: true
 
   /symbol-tree@3.2.4:
@@ -16988,7 +17051,7 @@ packages:
       detective: 5.2.1
       didyoumean: 1.2.2
       dlv: 1.1.3
-      fast-glob: 3.3.1
+      fast-glob: 3.2.11
       glob-parent: 6.0.2
       is-glob: 4.0.3
       lilconfig: 2.0.6
@@ -17003,7 +17066,7 @@ packages:
       postcss-selector-parser: 6.0.10
       postcss-value-parser: 4.2.0
       quick-lru: 5.1.1
-      resolve: 1.22.6
+      resolve: 1.22.1
     transitivePeerDependencies:
       - ts-node
 
@@ -17079,7 +17142,7 @@ packages:
       supports-hyperlinks: 2.3.0
     dev: true
 
-  /terser-webpack-plugin@5.3.9(@swc/core@1.3.83)(webpack@5.88.2):
+  /terser-webpack-plugin@5.3.9(@swc/core@1.3.83)(esbuild@0.16.17)(webpack@5.88.2):
     resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -17097,35 +17160,12 @@ packages:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.17
       '@swc/core': 1.3.83
+      esbuild: 0.16.17
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.19.4
-      webpack: 5.88.2(@swc/core@1.3.83)
-    dev: true
-
-  /terser-webpack-plugin@5.3.9(webpack@5.88.2):
-    resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      '@swc/core': '*'
-      esbuild: '*'
-      uglify-js: '*'
-      webpack: ^5.1.0
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      esbuild:
-        optional: true
-      uglify-js:
-        optional: true
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.17
-      jest-worker: 27.5.1
-      schema-utils: 3.3.0
-      serialize-javascript: 6.0.1
-      terser: 5.19.4
-      webpack: 5.88.2
+      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
     dev: true
 
   /terser@5.19.4:
@@ -17272,7 +17312,6 @@ packages:
 
   /tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
-    hasBin: true
     dev: true
 
   /ts-dedent@2.2.0:
@@ -17893,7 +17932,7 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.2.0
-      webpack: 5.88.2(@swc/core@1.3.83)
+      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
     dev: true
 
   /webpack-hot-middleware@2.25.4:
@@ -17913,7 +17952,7 @@ packages:
     resolution: {integrity: sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==}
     dev: true
 
-  /webpack@5.88.2:
+  /webpack@5.88.2(@swc/core@1.3.83)(esbuild@0.16.17):
     resolution: {integrity: sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -17928,8 +17967,8 @@ packages:
       '@webassemblyjs/ast': 1.11.6
       '@webassemblyjs/wasm-edit': 1.11.6
       '@webassemblyjs/wasm-parser': 1.11.6
-      acorn: 8.10.0
-      acorn-import-assertions: 1.9.0(acorn@8.10.0)
+      acorn: 8.8.1
+      acorn-import-assertions: 1.9.0(acorn@8.8.1)
       browserslist: 4.21.10
       chrome-trace-event: 1.0.3
       enhanced-resolve: 5.15.0
@@ -17944,47 +17983,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(webpack@5.88.2)
-      watchpack: 2.4.0
-      webpack-sources: 3.2.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-    dev: true
-
-  /webpack@5.88.2(@swc/core@1.3.83):
-    resolution: {integrity: sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-    peerDependencies:
-      webpack-cli: '*'
-    peerDependenciesMeta:
-      webpack-cli:
-        optional: true
-    dependencies:
-      '@types/eslint-scope': 3.7.4
-      '@types/estree': 1.0.1
-      '@webassemblyjs/ast': 1.11.6
-      '@webassemblyjs/wasm-edit': 1.11.6
-      '@webassemblyjs/wasm-parser': 1.11.6
-      acorn: 8.10.0
-      acorn-import-assertions: 1.9.0(acorn@8.10.0)
-      browserslist: 4.21.10
-      chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.15.0
-      es-module-lexer: 1.3.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.10
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.0
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 3.3.0
-      tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(@swc/core@1.3.83)(webpack@5.88.2)
+      terser-webpack-plugin: 5.3.9(@swc/core@1.3.83)(esbuild@0.16.17)(webpack@5.88.2)
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: '6.0'
 
 settings:
-  autoInstallPeers: true
+  autoInstallPeers: false
   excludeLinksFromLockfile: false
 
 importers:
@@ -31,7 +31,7 @@ importers:
         version: 8.0.3
       inquirer-autocomplete-prompt:
         specifier: ^3.0.0
-        version: 3.0.0(inquirer@9.2.11)
+        version: 3.0.0
       lint-staged:
         specifier: ^13.1.0
         version: 13.1.0
@@ -73,7 +73,7 @@ importers:
         version: 1.3.2(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.10)
       '@sanity/vision':
         specifier: ^3.9.1
-        version: 3.9.1(@babel/runtime@7.22.15)(@codemirror/lint@6.1.0)(@codemirror/state@6.2.0)(@codemirror/theme-one-dark@6.1.0)(@lezer/common@1.0.2)(codemirror@6.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.10)
+        version: 3.9.1(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.10)
       '@sanity/webhook':
         specifier: ^2.0.0
         version: 2.0.0
@@ -109,7 +109,7 @@ importers:
         version: 0.15.4
       groqd-playground:
         specifier: ^0.0.12
-        version: 0.0.12(@sanity/icons@2.3.1)(@sanity/ui@1.3.2)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(sanity@3.9.1)(styled-components@5.3.10)
+        version: 0.0.12(@sanity/ui@1.3.2)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(sanity@3.9.1)(styled-components@5.3.10)
       jsdom:
         specifier: ^20.0.0
         version: 20.0.0
@@ -118,10 +118,10 @@ importers:
         version: 4.0.8
       next:
         specifier: ^13.4.0
-        version: 13.4.0(@babel/core@7.22.15)(react-dom@18.2.0)(react@18.2.0)
+        version: 13.4.0(react-dom@18.2.0)(react@18.2.0)
       next-sanity:
         specifier: ^4.2.0
-        version: 4.2.0(@sanity/icons@2.3.1)(@sanity/types@3.9.1)(@sanity/ui@1.3.2)(@types/styled-components@5.1.26)(next@13.4.0)(react@18.2.0)(sanity@3.9.1)(styled-components@5.3.10)
+        version: 4.2.0(@sanity/ui@1.3.2)(next@13.4.0)(react@18.2.0)(sanity@3.9.1)(styled-components@5.3.10)
       node-fetch:
         specifier: ^3.2.10
         version: 3.2.10
@@ -173,7 +173,7 @@ importers:
         version: 0.2.2(jest@29.3.1)
       '@storybook/nextjs':
         specifier: ^7.4.0
-        version: 7.4.0(@swc/core@1.3.83)(@types/react-dom@18.0.6)(@types/react@18.0.18)(esbuild@0.16.17)(next@13.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.4)(webpack@5.88.2)
+        version: 7.4.0(@types/react-dom@18.0.6)(@types/react@18.0.18)(next@13.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.4)
       '@storybook/react':
         specifier: ^7.4.0
         version: 7.4.0(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.4)
@@ -1813,13 +1813,8 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
-  /@codemirror/autocomplete@6.4.0(@codemirror/language@6.4.0)(@codemirror/state@6.2.0)(@codemirror/view@6.7.3)(@lezer/common@1.0.2):
+  /@codemirror/autocomplete@6.4.0:
     resolution: {integrity: sha512-HLF2PnZAm1s4kGs30EiqKMgD7XsYaQ0XJnMR0rofEWQ5t5D60SfqpDIkIh1ze5tiEbyUWm8+VJ6W1/erVvBMIA==}
-    peerDependencies:
-      '@codemirror/language': ^6.0.0
-      '@codemirror/state': ^6.0.0
-      '@codemirror/view': ^6.0.0
-      '@lezer/common': ^1.0.0
     dependencies:
       '@codemirror/language': 6.4.0
       '@codemirror/state': 6.2.0
@@ -1839,7 +1834,7 @@ packages:
   /@codemirror/lang-javascript@6.1.2:
     resolution: {integrity: sha512-OcwLfZXdQ1OHrLiIcKCn7MqZ7nx205CMKlhe+vL88pe2ymhT9+2P+QhwkYGxMICj8TDHyp8HFKVwpiisUT7iEQ==}
     dependencies:
-      '@codemirror/autocomplete': 6.4.0(@codemirror/language@6.4.0)(@codemirror/state@6.2.0)(@codemirror/view@6.7.3)(@lezer/common@1.0.2)
+      '@codemirror/autocomplete': 6.4.0
       '@codemirror/language': 6.4.0
       '@codemirror/lint': 6.1.0
       '@codemirror/state': 6.2.0
@@ -3335,7 +3330,7 @@ packages:
       react-refresh: 0.11.0
       schema-utils: 3.3.0
       source-map: 0.7.4
-      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
+      webpack: 5.88.2
     dev: true
 
   /@portabletext/react@1.0.6(react@18.2.0):
@@ -4337,13 +4332,13 @@ packages:
       - supports-color
     dev: false
 
-  /@sanity/vision@3.9.1(@babel/runtime@7.22.15)(@codemirror/lint@6.1.0)(@codemirror/state@6.2.0)(@codemirror/theme-one-dark@6.1.0)(@lezer/common@1.0.2)(codemirror@6.0.1)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.10):
+  /@sanity/vision@3.9.1(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.10):
     resolution: {integrity: sha512-pRcaierrdo6rqL+59UBuNnMfATX5iobvaijFS/okqjdgloZHfhstph0W4GUp79cqxjZFi9qQffa2lguU3pWcjA==}
     peerDependencies:
       react: ^18
       styled-components: ^5.2
     dependencies:
-      '@codemirror/autocomplete': 6.4.0(@codemirror/language@6.4.0)(@codemirror/state@6.2.0)(@codemirror/view@6.7.3)(@lezer/common@1.0.2)
+      '@codemirror/autocomplete': 6.4.0
       '@codemirror/commands': 6.2.0
       '@codemirror/lang-javascript': 6.1.2
       '@codemirror/language': 6.4.0
@@ -4356,7 +4351,7 @@ packages:
       '@sanity/color': 2.2.2
       '@sanity/icons': 2.3.1(react@18.2.0)
       '@sanity/ui': 1.3.2(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.10)
-      '@uiw/react-codemirror': 4.19.7(@babel/runtime@7.22.15)(@codemirror/autocomplete@6.4.0)(@codemirror/language@6.4.0)(@codemirror/lint@6.1.0)(@codemirror/search@6.2.3)(@codemirror/state@6.2.0)(@codemirror/theme-one-dark@6.1.0)(@codemirror/view@6.7.3)(codemirror@6.0.1)(react-dom@18.2.0)(react@18.2.0)
+      '@uiw/react-codemirror': 4.19.7(@codemirror/autocomplete@6.4.0)(@codemirror/language@6.4.0)(@codemirror/search@6.2.3)(@codemirror/view@6.7.3)(react-dom@18.2.0)(react@18.2.0)
       hashlru: 2.3.0
       is-hotkey: 0.1.8
       json5: 2.2.3
@@ -4364,12 +4359,6 @@ packages:
       react: 18.2.0
       styled-components: 5.3.10(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
     transitivePeerDependencies:
-      - '@babel/runtime'
-      - '@codemirror/lint'
-      - '@codemirror/state'
-      - '@codemirror/theme-one-dark'
-      - '@lezer/common'
-      - codemirror
       - react-dom
       - react-is
     dev: false
@@ -4814,7 +4803,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/builder-webpack5@7.4.0(esbuild@0.16.17)(typescript@4.9.4):
+  /@storybook/builder-webpack5@7.4.0(typescript@4.9.4):
     resolution: {integrity: sha512-CYeXppqGACzDUpLCFvWvwD7IjN7VNi7+nwQ1uRNgW2NgBMOIldZe+gcTXcc0BuHyIitU5/vvquYM0qjis05LYw==}
     peerDependencies:
       typescript: '*'
@@ -4849,13 +4838,13 @@ packages:
       semver: 7.3.8
       style-loader: 3.3.3(webpack@5.88.2)
       swc-loader: 0.2.3(@swc/core@1.3.83)(webpack@5.88.2)
-      terser-webpack-plugin: 5.3.9(@swc/core@1.3.83)(esbuild@0.16.17)(webpack@5.88.2)
+      terser-webpack-plugin: 5.3.9(@swc/core@1.3.83)(webpack@5.88.2)
       ts-dedent: 2.2.0
       typescript: 4.9.4
       url: 0.11.1
       util: 0.12.4
       util-deprecate: 1.0.2
-      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
+      webpack: 5.88.2(@swc/core@1.3.83)
       webpack-dev-middleware: 6.1.1(webpack@5.88.2)
       webpack-hot-middleware: 2.25.4
       webpack-virtual-modules: 0.5.0
@@ -5209,7 +5198,7 @@ packages:
     resolution: {integrity: sha512-TXJJd5RAKakWx4BtpwvSNdgTDkKM6RkXU8GK34S/LhidQ5Pjz3wcnqb0TxEkfhK/ztbP8nKHqXFwLfa2CYkvQw==}
     dev: true
 
-  /@storybook/nextjs@7.4.0(@swc/core@1.3.83)(@types/react-dom@18.0.6)(@types/react@18.0.18)(esbuild@0.16.17)(next@13.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.4)(webpack@5.88.2):
+  /@storybook/nextjs@7.4.0(@types/react-dom@18.0.6)(@types/react@18.0.18)(next@13.4.0)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.4):
     resolution: {integrity: sha512-nGmer4Hu1/XX3+XyxfAkQ9d16Qsj467aLc7MTNQ2uFyYAksCqT3bvznooUOcD/X5NfoyL2YA78OczGdt1HFFpQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -5243,10 +5232,10 @@ packages:
       '@babel/preset-typescript': 7.22.15(@babel/core@7.22.15)
       '@babel/runtime': 7.22.15
       '@storybook/addon-actions': 7.4.0(@types/react-dom@18.0.6)(@types/react@18.0.18)(react-dom@18.2.0)(react@18.2.0)
-      '@storybook/builder-webpack5': 7.4.0(esbuild@0.16.17)(typescript@4.9.4)
+      '@storybook/builder-webpack5': 7.4.0(typescript@4.9.4)
       '@storybook/core-common': 7.4.0
       '@storybook/node-logger': 7.4.0
-      '@storybook/preset-react-webpack': 7.4.0(@babel/core@7.22.15)(@swc/core@1.3.83)(esbuild@0.16.17)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.4)
+      '@storybook/preset-react-webpack': 7.4.0(@babel/core@7.22.15)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.4)
       '@storybook/preview-api': 7.4.0
       '@storybook/react': 7.4.0(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.4)
       '@types/node': 16.18.48
@@ -5255,15 +5244,15 @@ packages:
       fs-extra: 11.1.1
       image-size: 1.0.2
       loader-utils: 3.2.1
-      next: 13.4.0(@babel/core@7.22.15)(react-dom@18.2.0)(react@18.2.0)
-      node-polyfill-webpack-plugin: 2.0.1(webpack@5.88.2)
+      next: 13.4.0(react-dom@18.2.0)(react@18.2.0)
+      node-polyfill-webpack-plugin: 2.0.1
       pnp-webpack-plugin: 1.7.0(typescript@4.9.4)
       postcss: 8.4.21
-      postcss-loader: 7.3.3(postcss@8.4.21)(typescript@4.9.4)(webpack@5.88.2)
+      postcss-loader: 7.3.3(postcss@8.4.21)(typescript@4.9.4)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       resolve-url-loader: 5.0.0
-      sass-loader: 12.6.0(webpack@5.88.2)
+      sass-loader: 12.6.0
       semver: 7.3.8
       style-loader: 3.3.3(webpack@5.88.2)
       styled-jsx: 5.1.1(@babel/core@7.22.15)(react@18.2.0)
@@ -5271,7 +5260,6 @@ packages:
       tsconfig-paths: 4.2.0
       tsconfig-paths-webpack-plugin: 4.1.0
       typescript: 4.9.4
-      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/helpers'
@@ -5303,7 +5291,7 @@ packages:
     resolution: {integrity: sha512-ZVBZggqkuj7ysfuHSCd/J7ovWV06zY9uWf+VU+Zw7ZeojDT8QHFrCurPsN7D9679j9vRU1/kSzqvAiStALS33g==}
     dev: true
 
-  /@storybook/preset-react-webpack@7.4.0(@babel/core@7.22.15)(@swc/core@1.3.83)(esbuild@0.16.17)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.4):
+  /@storybook/preset-react-webpack@7.4.0(@babel/core@7.22.15)(react-dom@18.2.0)(react@18.2.0)(typescript@4.9.4):
     resolution: {integrity: sha512-9iZ9lvhRUYtxXmJMqR7txNyatrHryqo6FSKzfpUzmcCySn3d7mu9I6LEPxEir43TkPnBio3W4EsbvtIhjJ5ekA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -5336,7 +5324,7 @@ packages:
       react-refresh: 0.11.0
       semver: 7.3.8
       typescript: 4.9.4
-      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
+      webpack: 5.88.2
     transitivePeerDependencies:
       - '@swc/core'
       - '@types/webpack'
@@ -5389,7 +5377,7 @@ packages:
       react-docgen-typescript: 2.2.2(typescript@4.9.4)
       tslib: 2.4.1
       typescript: 4.9.4
-      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
+      webpack: 5.88.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -5998,13 +5986,6 @@ packages:
       '@types/unist': 2.0.6
     dev: false
 
-  /@types/hoist-non-react-statics@3.3.1:
-    resolution: {integrity: sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==}
-    dependencies:
-      '@types/react': 18.0.18
-      hoist-non-react-statics: 3.3.2
-    dev: false
-
   /@types/html-minifier-terser@6.1.0:
     resolution: {integrity: sha512-oh/6byDPnL1zeNXFrDXFLyZjkr1MsBG667IM792caf1L2UPOOMf65NFzjUH/ltyfwjAGfs1rsX1eftK0jC/KIg==}
     dev: true
@@ -6250,14 +6231,6 @@ packages:
   /@types/stack-utils@2.0.1:
     resolution: {integrity: sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==}
     dev: true
-
-  /@types/styled-components@5.1.26:
-    resolution: {integrity: sha512-KuKJ9Z6xb93uJiIyxo/+ksS7yLjS1KzG6iv5i78dhVg/X3u5t1H7juRWqVmodIdz6wGVaIApo1u01kmFRdJHVw==}
-    dependencies:
-      '@types/hoist-non-react-statics': 3.3.1
-      '@types/react': 18.0.18
-      csstype: 3.1.1
-    dev: false
 
   /@types/testing-library__jest-dom@5.14.5:
     resolution: {integrity: sha512-SBwbxYoyPIvxHbeHxTZX2Pe/74F/tX2/D3mMvzabdeJ25bBojfW0TyB8BHrbq/9zaaKICJZjLP+8r6AeZMFCuQ==}
@@ -6526,18 +6499,16 @@ packages:
       eslint-visitor-keys: 3.3.0
     dev: true
 
-  /@uiw/codemirror-extensions-basic-setup@4.19.7(@codemirror/autocomplete@6.4.0)(@codemirror/commands@6.2.0)(@codemirror/language@6.4.0)(@codemirror/lint@6.1.0)(@codemirror/search@6.2.3)(@codemirror/state@6.2.0)(@codemirror/view@6.7.3):
+  /@uiw/codemirror-extensions-basic-setup@4.19.7(@codemirror/autocomplete@6.4.0)(@codemirror/commands@6.2.0)(@codemirror/language@6.4.0)(@codemirror/search@6.2.3)(@codemirror/view@6.7.3):
     resolution: {integrity: sha512-pk0JTFJAZOGxouBB1pdBtb59qKibO9DW4hER4VSFGBGW3TBDeXUwL/gKujhRpySHG2MtG09cgt4a3XOFIWwXTw==}
     peerDependencies:
       '@codemirror/autocomplete': '>=6.0.0'
       '@codemirror/commands': '>=6.0.0'
       '@codemirror/language': '>=6.0.0'
-      '@codemirror/lint': '>=6.0.0'
       '@codemirror/search': '>=6.0.0'
-      '@codemirror/state': '>=6.0.0'
       '@codemirror/view': '>=6.0.0'
     dependencies:
-      '@codemirror/autocomplete': 6.4.0(@codemirror/language@6.4.0)(@codemirror/state@6.2.0)(@codemirror/view@6.7.3)(@lezer/common@1.0.2)
+      '@codemirror/autocomplete': 6.4.0
       '@codemirror/commands': 6.2.0
       '@codemirror/language': 6.4.0
       '@codemirror/lint': 6.1.0
@@ -6546,14 +6517,10 @@ packages:
       '@codemirror/view': 6.7.3
     dev: false
 
-  /@uiw/react-codemirror@4.19.7(@babel/runtime@7.22.15)(@codemirror/autocomplete@6.4.0)(@codemirror/language@6.4.0)(@codemirror/lint@6.1.0)(@codemirror/search@6.2.3)(@codemirror/state@6.2.0)(@codemirror/theme-one-dark@6.1.0)(@codemirror/view@6.7.3)(codemirror@6.0.1)(react-dom@18.2.0)(react@18.2.0):
+  /@uiw/react-codemirror@4.19.7(@codemirror/autocomplete@6.4.0)(@codemirror/language@6.4.0)(@codemirror/search@6.2.3)(@codemirror/view@6.7.3)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-IHvpYWVSdiaHX0Fk6oY6YyAJigDnyvSpWKNUTRzsMNxB+8/wqZ8lior4TprXH0zyLxW5F1+bTyifFFTeg+X3Sw==}
     peerDependencies:
-      '@babel/runtime': '>=7.11.0'
-      '@codemirror/state': '>=6.0.0'
-      '@codemirror/theme-one-dark': '>=6.0.0'
       '@codemirror/view': '>=6.0.0'
-      codemirror: '>=6.0.0'
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
     dependencies:
@@ -6562,14 +6529,13 @@ packages:
       '@codemirror/state': 6.2.0
       '@codemirror/theme-one-dark': 6.1.0
       '@codemirror/view': 6.7.3
-      '@uiw/codemirror-extensions-basic-setup': 4.19.7(@codemirror/autocomplete@6.4.0)(@codemirror/commands@6.2.0)(@codemirror/language@6.4.0)(@codemirror/lint@6.1.0)(@codemirror/search@6.2.3)(@codemirror/state@6.2.0)(@codemirror/view@6.7.3)
-      codemirror: 6.0.1(@lezer/common@1.0.2)
+      '@uiw/codemirror-extensions-basic-setup': 4.19.7(@codemirror/autocomplete@6.4.0)(@codemirror/commands@6.2.0)(@codemirror/language@6.4.0)(@codemirror/search@6.2.3)(@codemirror/view@6.7.3)
+      codemirror: 6.0.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     transitivePeerDependencies:
       - '@codemirror/autocomplete'
       - '@codemirror/language'
-      - '@codemirror/lint'
       - '@codemirror/search'
     dev: false
 
@@ -6895,10 +6861,8 @@ packages:
       indent-string: 5.0.0
     dev: true
 
-  /ajv-formats@2.1.1(ajv@8.12.0):
+  /ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependencies:
-      ajv: ^8.0.0
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -7350,7 +7314,7 @@ packages:
       '@babel/core': 7.22.15
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
+      webpack: 5.88.2(@swc/core@1.3.83)
     dev: true
 
   /babel-plugin-add-react-displayname@0.0.5:
@@ -8110,18 +8074,16 @@ packages:
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
     dev: true
 
-  /codemirror@6.0.1(@lezer/common@1.0.2):
+  /codemirror@6.0.1:
     resolution: {integrity: sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==}
     dependencies:
-      '@codemirror/autocomplete': 6.4.0(@codemirror/language@6.4.0)(@codemirror/state@6.2.0)(@codemirror/view@6.7.3)(@lezer/common@1.0.2)
+      '@codemirror/autocomplete': 6.4.0
       '@codemirror/commands': 6.2.0
       '@codemirror/language': 6.4.0
       '@codemirror/lint': 6.1.0
       '@codemirror/search': 6.2.3
       '@codemirror/state': 6.2.0
       '@codemirror/view': 6.7.3
-    transitivePeerDependencies:
-      - '@lezer/common'
     dev: false
 
   /collect-v8-coverage@1.0.1:
@@ -8526,7 +8488,7 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.4.21)
       postcss-value-parser: 4.2.0
       semver: 7.3.8
-      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
+      webpack: 5.88.2(@swc/core@1.3.83)
     dev: true
 
   /css-select@4.3.0:
@@ -9532,7 +9494,7 @@ packages:
       eslint: 8.23.0
       eslint-import-resolver-node: 0.3.6
       eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.26.0)(eslint@8.23.0)
-      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.48.1)(eslint@8.23.0)
+      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.36.1)(eslint-import-resolver-typescript@2.7.1)(eslint@8.23.0)
       eslint-plugin-jsx-a11y: 6.6.1(eslint@8.23.0)
       eslint-plugin-react: 7.31.1(eslint@8.23.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.23.0)
@@ -9569,7 +9531,7 @@ packages:
     dependencies:
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.23.0
-      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.48.1)(eslint@8.23.0)
+      eslint-plugin-import: 2.26.0(@typescript-eslint/parser@5.36.1)(eslint-import-resolver-typescript@2.7.1)(eslint@8.23.0)
       glob: 7.2.3
       is-glob: 4.0.3
       resolve: 1.22.6
@@ -9578,7 +9540,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils@2.7.4(@typescript-eslint/parser@5.48.1)(eslint-import-resolver-node@0.3.6)(eslint@8.23.0):
+  /eslint-module-utils@2.7.4(@typescript-eslint/parser@5.36.1)(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@2.7.1)(eslint@8.23.0):
     resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -9599,15 +9561,16 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.48.1(eslint@8.31.0)(typescript@4.9.4)
+      '@typescript-eslint/parser': 5.36.1(eslint@8.23.0)(typescript@4.9.4)
       debug: 3.2.7(supports-color@8.1.1)
       eslint: 8.23.0
       eslint-import-resolver-node: 0.3.6
+      eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.26.0)(eslint@8.23.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.48.1)(eslint@8.23.0):
+  /eslint-plugin-import@2.26.0(@typescript-eslint/parser@5.36.1)(eslint-import-resolver-typescript@2.7.1)(eslint@8.23.0):
     resolution: {integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -9617,14 +9580,14 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.48.1(eslint@8.31.0)(typescript@4.9.4)
+      '@typescript-eslint/parser': 5.36.1(eslint@8.23.0)(typescript@4.9.4)
       array-includes: 3.1.5
       array.prototype.flat: 1.3.0
       debug: 2.6.9
       doctrine: 2.1.0
       eslint: 8.23.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.48.1)(eslint-import-resolver-node@0.3.6)(eslint@8.23.0)
+      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.36.1)(eslint-import-resolver-node@0.3.6)(eslint-import-resolver-typescript@2.7.1)(eslint@8.23.0)
       has: 1.0.3
       is-core-module: 2.10.0
       is-glob: 4.0.3
@@ -10539,7 +10502,7 @@ packages:
       semver: 7.5.4
       tapable: 2.2.1
       typescript: 4.9.4
-      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
+      webpack: 5.88.2(@swc/core@1.3.83)
     dev: true
 
   /form-data@2.3.3:
@@ -11107,7 +11070,7 @@ packages:
     engines: {node: '>=14'}
     dev: false
 
-  /groqd-playground@0.0.12(@sanity/icons@2.3.1)(@sanity/ui@1.3.2)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(sanity@3.9.1)(styled-components@5.3.10):
+  /groqd-playground@0.0.12(@sanity/ui@1.3.2)(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(sanity@3.9.1)(styled-components@5.3.10):
     resolution: {integrity: sha512-Chlup0BRl1Rg5RAYXdwtvcJlI9MMVjfoVpJJLBBLZzBuhiqdgYIwz9+URfvmHN5k/UPYNFVVYa5tSoeHnFFquQ==}
     peerDependencies:
       '@sanity/icons': ^2.3.1
@@ -11118,7 +11081,6 @@ packages:
       sanity: ^3.0.0
       styled-components: ^5.3.9
     dependencies:
-      '@sanity/icons': 2.3.1(react@18.2.0)
       '@sanity/ui': 1.3.2(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.10)
       '@uiw/react-split': 5.8.10(react-dom@18.2.0)(react@18.2.0)
       groqd: 0.15.4
@@ -11344,7 +11306,7 @@ packages:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
+      webpack: 5.88.2(@swc/core@1.3.83)
     dev: true
 
   /htmlparser2@3.10.1:
@@ -11573,7 +11535,7 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /inquirer-autocomplete-prompt@3.0.0(inquirer@9.2.11):
+  /inquirer-autocomplete-prompt@3.0.0:
     resolution: {integrity: sha512-nsPWllBQB3qhvpVgV1UIJN4xo3yz7Qv8y1+zrNVpJUNPxtUZ7btCum/4UCAs5apPCe/FVhKH1V6Wx0cAwkreyg==}
     engines: {node: '>=12'}
     peerDependencies:
@@ -11581,7 +11543,6 @@ packages:
     dependencies:
       ansi-escapes: 6.2.0
       figures: 5.0.0
-      inquirer: 9.2.11
       picocolors: 1.0.0
       run-async: 2.4.1
       rxjs: 7.8.1
@@ -14019,7 +13980,7 @@ packages:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
     dev: true
 
-  /next-sanity@4.2.0(@sanity/icons@2.3.1)(@sanity/types@3.9.1)(@sanity/ui@1.3.2)(@types/styled-components@5.1.26)(next@13.4.0)(react@18.2.0)(sanity@3.9.1)(styled-components@5.3.10):
+  /next-sanity@4.2.0(@sanity/ui@1.3.2)(next@13.4.0)(react@18.2.0)(sanity@3.9.1)(styled-components@5.3.10):
     resolution: {integrity: sha512-4GNEgXXDWPlvXqdJaAfKBR8BNvwQqUCynJ9GCgL6tVGcfZvcAImyZkzLTXj75PTZDPDcc7OfKHXg+XbmbUp7hA==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -14033,14 +13994,11 @@ packages:
       styled-components: ^5.2
     dependencies:
       '@sanity/client': 5.4.2
-      '@sanity/icons': 2.3.1(react@18.2.0)
       '@sanity/preview-kit': 1.4.0(react@18.2.0)
-      '@sanity/types': 3.9.1
       '@sanity/ui': 1.3.2(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)(styled-components@5.3.10)
       '@sanity/webhook': 2.0.0
-      '@types/styled-components': 5.1.26
       groq: 3.9.1
-      next: 13.4.0(@babel/core@7.22.15)(react-dom@18.2.0)(react@18.2.0)
+      next: 13.4.0(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       sanity: 3.9.1(@types/node@18.7.14)(@types/react@18.0.18)(react-dom@18.2.0)(react@18.2.0)(styled-components@5.3.10)
       styled-components: 5.3.10(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
@@ -14048,7 +14006,7 @@ packages:
       - supports-color
     dev: false
 
-  /next@13.4.0(@babel/core@7.22.15)(react-dom@18.2.0)(react@18.2.0):
+  /next@13.4.0(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-y3E+2ZjiVrphkz7zcJvd2rEG6miOekI8krPfWV4AZZ9TaF0LDuFdP/f+RQ5M9wRvsz6GWw8k8+7jsO860GxSqg==}
     engines: {node: '>=16.8.0'}
     hasBin: true
@@ -14163,7 +14121,7 @@ packages:
       upper-case: 2.0.2
     dev: true
 
-  /node-polyfill-webpack-plugin@2.0.1(webpack@5.88.2):
+  /node-polyfill-webpack-plugin@2.0.1:
     resolution: {integrity: sha512-ZUMiCnZkP1LF0Th2caY6J/eKKoA0TefpoVa68m/LQU1I/mE8rGt4fNYGgNuCcK+aG8P8P43nbeJ2RqJMOL/Y1A==}
     engines: {node: '>=12'}
     peerDependencies:
@@ -14194,7 +14152,6 @@ packages:
       url: 0.11.1
       util: 0.12.4
       vm-browserify: 1.1.2
-      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
     dev: true
 
   /node-preload@0.2.1:
@@ -15005,7 +14962,7 @@ packages:
       postcss: 8.4.16
       yaml: 1.10.2
 
-  /postcss-loader@7.3.3(postcss@8.4.21)(typescript@4.9.4)(webpack@5.88.2):
+  /postcss-loader@7.3.3(postcss@8.4.21)(typescript@4.9.4):
     resolution: {integrity: sha512-YgO/yhtevGO/vJePCQmTxiaEwER94LABZN0ZMT4A0vsak9TpO+RvKRs7EmJ8peIlB9xfXCsS7M8LjqncsUZ5HA==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -15016,7 +14973,6 @@ packages:
       jiti: 1.20.0
       postcss: 8.4.21
       semver: 7.3.8
-      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -16224,7 +16180,7 @@ packages:
       - utf-8-validate
     dev: false
 
-  /sass-loader@12.6.0(webpack@5.88.2):
+  /sass-loader@12.6.0:
     resolution: {integrity: sha512-oLTaH0YCtX4cfnJZxKSLAyglED0naiYfNG1iXfU5w1LNZ+ukoA5DtyDIN5zmKVZwYNJP4KRc5Y3hkWga+7tYfA==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -16245,7 +16201,6 @@ packages:
     dependencies:
       klona: 2.0.6
       neo-async: 2.6.2
-      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
     dev: true
 
   /saxes@6.0.0:
@@ -16274,7 +16229,7 @@ packages:
     dependencies:
       '@types/json-schema': 7.0.11
       ajv: 8.12.0
-      ajv-formats: 2.1.1(ajv@8.12.0)
+      ajv-formats: 2.1.1
       ajv-keywords: 5.1.0(ajv@8.12.0)
     dev: true
 
@@ -16929,7 +16884,7 @@ packages:
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
+      webpack: 5.88.2(@swc/core@1.3.83)
     dev: true
 
   /style-mod@4.0.0:
@@ -17028,7 +16983,7 @@ packages:
       webpack: '>=2'
     dependencies:
       '@swc/core': 1.3.83
-      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
+      webpack: 5.88.2(@swc/core@1.3.83)
     dev: true
 
   /symbol-tree@3.2.4:
@@ -17142,7 +17097,7 @@ packages:
       supports-hyperlinks: 2.3.0
     dev: true
 
-  /terser-webpack-plugin@5.3.9(@swc/core@1.3.83)(esbuild@0.16.17)(webpack@5.88.2):
+  /terser-webpack-plugin@5.3.9(@swc/core@1.3.83)(webpack@5.88.2):
     resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -17160,12 +17115,35 @@ packages:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.17
       '@swc/core': 1.3.83
-      esbuild: 0.16.17
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.19.4
-      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
+      webpack: 5.88.2(@swc/core@1.3.83)
+    dev: true
+
+  /terser-webpack-plugin@5.3.9(webpack@5.88.2):
+    resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@swc/core': '*'
+      esbuild: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      esbuild:
+        optional: true
+      uglify-js:
+        optional: true
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.17
+      jest-worker: 27.5.1
+      schema-utils: 3.3.0
+      serialize-javascript: 6.0.1
+      terser: 5.19.4
+      webpack: 5.88.2
     dev: true
 
   /terser@5.19.4:
@@ -17932,7 +17910,7 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.2.0
-      webpack: 5.88.2(@swc/core@1.3.83)(esbuild@0.16.17)
+      webpack: 5.88.2(@swc/core@1.3.83)
     dev: true
 
   /webpack-hot-middleware@2.25.4:
@@ -17952,7 +17930,7 @@ packages:
     resolution: {integrity: sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==}
     dev: true
 
-  /webpack@5.88.2(@swc/core@1.3.83)(esbuild@0.16.17):
+  /webpack@5.88.2:
     resolution: {integrity: sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -17983,7 +17961,47 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(@swc/core@1.3.83)(esbuild@0.16.17)(webpack@5.88.2)
+      terser-webpack-plugin: 5.3.9(webpack@5.88.2)
+      watchpack: 2.4.0
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+    dev: true
+
+  /webpack@5.88.2(@swc/core@1.3.83):
+    resolution: {integrity: sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
+    dependencies:
+      '@types/eslint-scope': 3.7.4
+      '@types/estree': 1.0.1
+      '@webassemblyjs/ast': 1.11.6
+      '@webassemblyjs/wasm-edit': 1.11.6
+      '@webassemblyjs/wasm-parser': 1.11.6
+      acorn: 8.8.1
+      acorn-import-assertions: 1.9.0(acorn@8.8.1)
+      browserslist: 4.21.10
+      chrome-trace-event: 1.0.3
+      enhanced-resolve: 5.15.0
+      es-module-lexer: 1.3.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.10
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.0
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 3.3.0
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.9(@swc/core@1.3.83)(webpack@5.88.2)
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:


### PR DESCRIPTION
### What
Upgrade pnpm to v8

### Why
Breakout update to isolate breaking changes

### Info
Vercel automatically supports v8 with a 6.0 lockfile https://vercel.com/changelog/automatic-pnpm-v8-support

It seems like we are in a bit of a mixed state between lockfile 6.0 and pnpm@8. Running `pnpm i` with the latest lockfile won't make any changes, however if you delete the lockfile and run it will generate the new file (as in this PR) with `autoInstallPeers: true` which is the major change. This is also true if you make any workspaces changes, which is what I am running into.

This is breaking CI which has [frozen lockfile settings](https://pnpm.io/cli/install#--frozen-lockfile). My PR was [failing due to this change](https://vercel.com/formidable-labs/nextjs-sanity-fe/2tEiFP954rcRvYjaaKPmGAf7sxwa). Downgrading my pnpm was not the answer, and this change to `pnpm-lock.yml` seems almost unavoidable with the latest pnpm version once you make any change.

### Help
We'll need to get around the frozen lockfile as a one-time deal 🤔 